### PR TITLE
Remove broken build status indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Stripe Agent Toolkit
 
-[![Build Status](https://github.com/stripe/agent-toolkit/actions/workflows/main.yml/badge.svg)](https://github.com/stripe/agent-toolkit/actions/workflows/main.yml)
-
 The Stripe Agent Toolkit enables popular agent frameworks including LangChain,
 CrewAI, and Vercel's AI SDK, to integrate with Stripe APIs through function calling. The
 library is not exhaustive of the entire Stripe API. It includes support for both Python and TypeScript and is built directly on top of the Stripe [Python][python-sdk] and [Node][node-sdk] SDKs.


### PR DESCRIPTION
It only works internally for Stripe employees. Removing for now as the broken image is the first thing you see when landing on the page.