### PR TITLE
fix names with spaces bug

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stripe-agent-toolkit"
-version = "0.1.16"
+version = "0.1.21"
 description = "Stripe Agent Toolkit"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/python/stripe_agent_toolkit/api.py
+++ b/python/stripe_agent_toolkit/api.py
@@ -29,7 +29,7 @@ class StripeAPI(BaseModel):
         stripe.api_key = secret_key
         stripe.set_app_info(
             "stripe-agent-toolkit-python",
-            version="0.1.16",
+            version="0.1.21",
             url="https://github.com/stripe/agent-toolkit",
         )
 

--- a/python/stripe_agent_toolkit/functions.py
+++ b/python/stripe_agent_toolkit/functions.py
@@ -161,13 +161,13 @@ def finalize_invoice(invoice: str):
     Returns:
         stripe.Invoice: The finalized invoice.
     """
-    invoice = stripe.Invoice.finalize_invoice(invoice=invoice)
+    invoice_object = stripe.Invoice.finalize_invoice(invoice=invoice)
 
     return {
-        "id": invoice.id,
-        "hosted_invoice_url": invoice.hosted_invoice_url,
-        "customer": invoice.customer,
-        "status": invoice.status,
+        "id": invoice_object.id,
+        "hosted_invoice_url": invoice_object.hosted_invoice_url,
+        "customer": invoice_object.customer,
+        "status": invoice_object.status,
     }
 
 

--- a/python/stripe_agent_toolkit/langchain/toolkit.py
+++ b/python/stripe_agent_toolkit/langchain/toolkit.py
@@ -23,7 +23,7 @@ class StripeAgentToolkit:
 
         self._tools = [
             StripeTool(
-                name=tool["name"],
+                name=tool["method"],
                 description=tool["description"],
                 method=tool["method"],
                 stripe_api=stripe_api,

--- a/python/stripe_agent_toolkit/tools.py
+++ b/python/stripe_agent_toolkit/tools.py
@@ -38,7 +38,7 @@ tools: List[Dict] = [
             "customers": {
                 "create": True,
             }
-        }
+        },
     },
     {
         "method": "list_customers",
@@ -49,7 +49,7 @@ tools: List[Dict] = [
             "customers": {
                 "read": True,
             }
-        }
+        },
     },
     {
         "method": "create_product",
@@ -60,7 +60,7 @@ tools: List[Dict] = [
             "products": {
                 "create": True,
             }
-        }
+        },
     },
     {
         "method": "list_products",
@@ -71,7 +71,7 @@ tools: List[Dict] = [
             "products": {
                 "read": True,
             }
-        }
+        },
     },
     {
         "method": "create_price",
@@ -82,7 +82,7 @@ tools: List[Dict] = [
             "prices": {
                 "create": True,
             }
-        }
+        },
     },
     {
         "method": "list_prices",
@@ -93,7 +93,7 @@ tools: List[Dict] = [
             "prices": {
                 "read": True,
             }
-        }
+        },
     },
     {
         "method": "create_payment_link",
@@ -104,7 +104,7 @@ tools: List[Dict] = [
             "payment_links": {
                 "create": True,
             }
-        }
+        },
     },
     {
         "method": "create_invoice",
@@ -115,7 +115,7 @@ tools: List[Dict] = [
             "invoices": {
                 "create": True,
             }
-        }
+        },
     },
     {
         "method": "create_invoice_item",
@@ -126,7 +126,7 @@ tools: List[Dict] = [
             "invoice_items": {
                 "create": True,
             }
-        }
+        },
     },
     {
         "method": "finalize_invoice",
@@ -137,7 +137,7 @@ tools: List[Dict] = [
             "invoices": {
                 "update": True,
             }
-        }
+        },
     },
     {
         "method": "retrieve_balance",
@@ -148,6 +148,6 @@ tools: List[Dict] = [
             "balance": {
                 "read": True,
             }
-        }
+        },
     },
 ]

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/agent-toolkit",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "scripts": {
     "build": "tsup",
     "clean": "rm -rf langchain ai-sdk",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@stripe/agent-toolkit",
   "version": "0.1.21",
+  "homepage": "https://github.com/stripe/agent-toolkit",
   "scripts": {
     "build": "tsup",
     "clean": "rm -rf langchain ai-sdk",

--- a/typescript/src/langchain/tool.ts
+++ b/typescript/src/langchain/tool.ts
@@ -18,7 +18,6 @@ class StripeTool extends StructuredTool {
   constructor(
     StripeAPI: StripeAPI,
     method: string,
-    name: string,
     description: string,
     schema: z.ZodObject<any, any, any, any, {[x: string]: any}>
   ) {
@@ -26,7 +25,7 @@ class StripeTool extends StructuredTool {
 
     this.stripeAPI = StripeAPI;
     this.method = method;
-    this.name = name;
+    this.name = method;
     this.description = description;
     this.schema = schema;
   }

--- a/typescript/src/langchain/toolkit.ts
+++ b/typescript/src/langchain/toolkit.ts
@@ -27,7 +27,6 @@ class StripeAgentToolkit implements BaseToolkit {
         new StripeTool(
           this._stripe,
           tool.method,
-          tool.name,
           tool.description,
           tool.parameters
         )

--- a/typescript/src/shared/api.ts
+++ b/typescript/src/shared/api.ts
@@ -20,7 +20,7 @@ class StripeAPI {
     const stripeClient = new Stripe(secretKey, {
       appInfo: {
         name: 'stripe-agent-toolkit-typescript',
-        version: '0.1.20',
+        version: '0.1.21',
         url: 'https://github.com/stripe/agent-toolkit',
       },
     });
@@ -46,37 +46,37 @@ class StripeAPI {
   }
 
   async run(method: string, arg: any) {
-    if (method === 'createCustomer') {
+    if (method === 'create_customer') {
       const output = JSON.stringify(await createCustomer(this.stripe, arg));
       return output;
-    } else if (method === 'listCustomers') {
+    } else if (method === 'list_customers') {
       const output = JSON.stringify(await listCustomers(this.stripe, arg));
       return output;
-    } else if (method === 'createProduct') {
+    } else if (method === 'create_product') {
       const output = JSON.stringify(await createProduct(this.stripe, arg));
       return output;
-    } else if (method === 'listProducts') {
+    } else if (method === 'list_products') {
       const output = JSON.stringify(await listProducts(this.stripe, arg));
       return output;
-    } else if (method === 'createPrice') {
+    } else if (method === 'create_price') {
       const output = JSON.stringify(await createPrice(this.stripe, arg));
       return output;
-    } else if (method === 'listPrices') {
+    } else if (method === 'list_prices') {
       const output = JSON.stringify(await listPrices(this.stripe, arg));
       return output;
-    } else if (method === 'createPaymentLink') {
+    } else if (method === 'create_payment_link') {
       const output = JSON.stringify(await createPaymentLink(this.stripe, arg));
       return output;
-    } else if (method === 'createInvoice') {
+    } else if (method === 'create_invoice') {
       const output = JSON.stringify(await createInvoice(this.stripe, arg));
       return output;
-    } else if (method === 'createInvoiceItem') {
+    } else if (method === 'create_invoice_item') {
       const output = JSON.stringify(await createInvoiceItem(this.stripe, arg));
       return output;
-    } else if (method === 'finalizeInvoice') {
+    } else if (method === 'finalize_invoice') {
       const output = JSON.stringify(await finalizeInvoice(this.stripe, arg));
       return output;
-    } else if (method === 'retrieveBalance') {
+    } else if (method === 'retrieve_balance') {
       const output = JSON.stringify(await retrieveBalance(this.stripe, arg));
       return output;
     } else {

--- a/typescript/src/shared/tools.ts
+++ b/typescript/src/shared/tools.ts
@@ -40,7 +40,7 @@ export type Tool = {
 
 const tools: Tool[] = [
   {
-    method: 'createCustomer',
+    method: 'create_customer',
     name: 'Create Customer',
     description: createCustomerPrompt,
     parameters: createCustomerParameters,
@@ -51,7 +51,7 @@ const tools: Tool[] = [
     },
   },
   {
-    method: 'listCustomers',
+    method: 'list_customers',
     name: 'List Customers',
     description: listCustomersPrompt,
     parameters: listCustomersParameters,
@@ -62,7 +62,7 @@ const tools: Tool[] = [
     },
   },
   {
-    method: 'createProduct',
+    method: 'create_product',
     name: 'Create Product',
     description: createProductPrompt,
     parameters: createProductParameters,
@@ -73,7 +73,7 @@ const tools: Tool[] = [
     },
   },
   {
-    method: 'listProducts',
+    method: 'list_products',
     name: 'List Products',
     description: listProductsPrompt,
     parameters: listProductsParameters,
@@ -84,7 +84,7 @@ const tools: Tool[] = [
     },
   },
   {
-    method: 'createPrice',
+    method: 'create_price',
     name: 'Create Price',
     description: createPricePrompt,
     parameters: createPriceParameters,
@@ -95,7 +95,7 @@ const tools: Tool[] = [
     },
   },
   {
-    method: 'listPrices',
+    method: 'list_prices',
     name: 'List Prices',
     description: listPricesPrompt,
     parameters: listPricesParameters,
@@ -106,7 +106,7 @@ const tools: Tool[] = [
     },
   },
   {
-    method: 'createPaymentLink',
+    method: 'create_payment_link',
     name: 'Create Payment Link',
     description: createPaymentLinkPrompt,
     parameters: createPaymentLinkParameters,
@@ -117,7 +117,7 @@ const tools: Tool[] = [
     },
   },
   {
-    method: 'createInvoice',
+    method: 'create_invoice',
     name: 'Create Invoice',
     description: createInvoicePrompt,
     parameters: createInvoiceParameters,
@@ -128,7 +128,7 @@ const tools: Tool[] = [
     },
   },
   {
-    method: 'createInvoiceItem',
+    method: 'create_invoice_item',
     name: 'Create Invoice Item',
     description: createInvoiceItemPrompt,
     parameters: createInvoiceItemParameters,
@@ -139,7 +139,7 @@ const tools: Tool[] = [
     },
   },
   {
-    method: 'finalizeInvoice',
+    method: 'finalize_invoice',
     name: 'Finalize Invoice',
     description: finalizeInvoicePrompt,
     parameters: finalizeInvoiceParameters,
@@ -150,7 +150,7 @@ const tools: Tool[] = [
     },
   },
   {
-    method: 'retrieveBalance',
+    method: 'retrieve_balance',
     name: 'Retrieve Balance',
     description: retrieveBalancePrompt,
     parameters: retrieveBalanceParameters,


### PR DESCRIPTION
There was a bug where function names with spaces (e.g `Create Payment Link`) errored out since it had a space. This just uses the `method` value instead, but keeps 