### PR TITLE
add context to configuration to support connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ stripe_agent = Agent(
 
 Examples for LangChain and CrewAI are included in [/examples](/python/examples).
 
+#### Context
+
+In some cases you will want to provide values that serve as defaults when making requests. Currently, the `account` context value enables you to make API calls for your [connected accounts](https://docs.stripe.com/connect/authentication).
+
+```python
+stripe_agent_toolkit = StripeAgentToolkit(
+    secret_key="sk_test_...",
+    configuration={
+      "context": {
+        "account": "acct_123"
+      }
+    }
+)
+```
+
 ## TypeScript
 
 ### Installation
@@ -109,6 +124,21 @@ const agentExecutor = new AgentExecutor({
   agent,
   tools,
 });
+```
+
+#### Context
+
+In some cases you will want to provide values that serve as defaults when making requests. Currently, the `account` context value enables you to make API calls for your [connected accounts](https://docs.stripe.com/connect/authentication).
+
+```typescript
+const stripeAgentToolkit = new StripeAgentToolkit({
+  secretKey: process.env.STRIPE_SECRET_KEY!,
+  configuration: {
+    context: {
+      account: 'acct_123',
+    }
+  }
+})
 ```
 
 #### Metered billing

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ In some cases you will want to provide values that serve as defaults when making
 stripe_agent_toolkit = StripeAgentToolkit(
     secret_key="sk_test_...",
     configuration={
-      "context": {
-        "account": "acct_123"
-      }
+        "context": {
+            "account": "acct_123"
+        }
     }
 )
 ```
@@ -136,8 +136,8 @@ const stripeAgentToolkit = new StripeAgentToolkit({
   configuration: {
     context: {
       account: 'acct_123',
-    }
-  }
+    },
+  },
 })
 ```
 

--- a/python/README.md
+++ b/python/README.md
@@ -63,9 +63,9 @@ In some cases you will want to provide values that serve as defaults when making
 stripe_agent_toolkit = StripeAgentToolkit(
     secret_key="sk_test_...",
     configuration={
-      "context": {
-        "account": "acct_123"
-      }
+        "context": {
+            "account": "acct_123"
+        }
     }
 )
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -55,6 +55,21 @@ Examples for LangChain and CrewAI are included in `/examples`.
 [python-sdk]: https://github.com/stripe/stripe-python
 [api-keys]: https://dashboard.stripe.com/account/apikeys
 
+#### Context
+
+In some cases you will want to provide values that serve as defaults when making requests. Currently, the `account` context value enables you to make API calls for your [connected accounts](https://docs.stripe.com/connect/authentication).
+
+```python
+stripe_agent_toolkit = StripeAgentToolkit(
+    secret_key="sk_test_...",
+    configuration={
+      "context": {
+        "account": "acct_123"
+      }
+    }
+)
+```
+
 ## Development
 
 ```

--- a/python/stripe_agent_toolkit/api.py
+++ b/python/stripe_agent_toolkit/api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import stripe
+from typing import Optional
 from pydantic import BaseModel
 
 from .configuration import Context
@@ -26,12 +27,12 @@ from .functions import (
 class StripeAPI(BaseModel):
     """ "Wrapper for Stripe API"""
 
-    context: Context
+    _context: Context
 
-    def __init__(self, secret_key: str, context: Context):
+    def __init__(self, secret_key: str, context: Optional[Context]):
         super().__init__()
 
-        self.context = context
+        self._context = context if context is not None else Context()
 
         stripe.api_key = secret_key
         stripe.set_app_info(
@@ -42,30 +43,30 @@ class StripeAPI(BaseModel):
 
     def run(self, method: str, *args, **kwargs) -> str:
         if method == "create_customer":
-            return json.dumps(create_customer(self.context, *args, **kwargs))
+            return json.dumps(create_customer(self._context, *args, **kwargs))
         elif method == "list_customers":
-            return json.dumps(list_customers(self.context, *args, **kwargs))
+            return json.dumps(list_customers(self._context, *args, **kwargs))
         elif method == "create_product":
-            return json.dumps(create_product(self.context, *args, **kwargs))
+            return json.dumps(create_product(self._context, *args, **kwargs))
         elif method == "list_products":
-            return json.dumps(list_products(self.context, *args, **kwargs))
+            return json.dumps(list_products(self._context, *args, **kwargs))
         elif method == "create_price":
-            return json.dumps(create_price(self.context, *args, **kwargs))
+            return json.dumps(create_price(self._context, *args, **kwargs))
         elif method == "list_prices":
-            return json.dumps(list_prices(self.context, *args, **kwargs))
+            return json.dumps(list_prices(self._context, *args, **kwargs))
         elif method == "create_payment_link":
             return json.dumps(
-                create_payment_link(self.context, *args, **kwargs)
+                create_payment_link(self._context, *args, **kwargs)
             )
         elif method == "create_invoice":
-            return json.dumps(create_invoice(self.context, *args, **kwargs))
+            return json.dumps(create_invoice(self._context, *args, **kwargs))
         elif method == "create_invoice_item":
             return json.dumps(
-                create_invoice_item(self.context, *args, **kwargs)
+                create_invoice_item(self._context, *args, **kwargs)
             )
         elif method == "finalize_invoice":
-            return json.dumps(finalize_invoice(self.context, *args, **kwargs))
+            return json.dumps(finalize_invoice(self._context, *args, **kwargs))
         elif method == "retrieve_balance":
-            return json.dumps(retrieve_balance(self.context, *args, **kwargs))
+            return json.dumps(retrieve_balance(self._context, *args, **kwargs))
         else:
             raise ValueError("Invalid method " + method)

--- a/python/stripe_agent_toolkit/api.py
+++ b/python/stripe_agent_toolkit/api.py
@@ -6,6 +6,8 @@ import json
 import stripe
 from pydantic import BaseModel
 
+from .configuration import Context
+
 from .functions import (
     create_customer,
     list_customers,
@@ -24,8 +26,13 @@ from .functions import (
 class StripeAPI(BaseModel):
     """ "Wrapper for Stripe API"""
 
-    def __init__(self, secret_key: str):
+    context: Context
+
+    def __init__(self, secret_key: str, context: Context):
         super().__init__()
+
+        self.context = context
+
         stripe.api_key = secret_key
         stripe.set_app_info(
             "stripe-agent-toolkit-python",
@@ -35,26 +42,30 @@ class StripeAPI(BaseModel):
 
     def run(self, method: str, *args, **kwargs) -> str:
         if method == "create_customer":
-            return json.dumps(create_customer(*args, **kwargs))
+            return json.dumps(create_customer(self.context, *args, **kwargs))
         elif method == "list_customers":
-            return json.dumps(list_customers(*args, **kwargs))
+            return json.dumps(list_customers(self.context, *args, **kwargs))
         elif method == "create_product":
-            return json.dumps(create_product(*args, **kwargs))
+            return json.dumps(create_product(self.context, *args, **kwargs))
         elif method == "list_products":
-            return json.dumps(list_products(*args, **kwargs))
+            return json.dumps(list_products(self.context, *args, **kwargs))
         elif method == "create_price":
-            return json.dumps(create_price(*args, **kwargs))
+            return json.dumps(create_price(self.context, *args, **kwargs))
         elif method == "list_prices":
-            return json.dumps(list_prices(*args, **kwargs))
+            return json.dumps(list_prices(self.context, *args, **kwargs))
         elif method == "create_payment_link":
-            return json.dumps(create_payment_link(*args, **kwargs))
+            return json.dumps(
+                create_payment_link(self.context, *args, **kwargs)
+            )
         elif method == "create_invoice":
-            return json.dumps(create_invoice(*args, **kwargs))
+            return json.dumps(create_invoice(self.context, *args, **kwargs))
         elif method == "create_invoice_item":
-            return json.dumps(create_invoice_item(*args, **kwargs))
+            return json.dumps(
+                create_invoice_item(self.context, *args, **kwargs)
+            )
         elif method == "finalize_invoice":
-            return json.dumps(finalize_invoice(*args, **kwargs))
+            return json.dumps(finalize_invoice(self.context, *args, **kwargs))
         elif method == "retrieve_balance":
-            return json.dumps(retrieve_balance(*args, **kwargs))
+            return json.dumps(retrieve_balance(self.context, *args, **kwargs))
         else:
             raise ValueError("Invalid method " + method)

--- a/python/stripe_agent_toolkit/configuration.py
+++ b/python/stripe_agent_toolkit/configuration.py
@@ -1,4 +1,5 @@
-from typing import TypedDict, Literal, Optional
+from typing import Literal, Optional
+from typing_extensions import TypedDict
 
 # Define Object type
 Object = Literal[

--- a/python/stripe_agent_toolkit/configuration.py
+++ b/python/stripe_agent_toolkit/configuration.py
@@ -35,9 +35,15 @@ class Actions(TypedDict, total=False):
     balance: Optional[BalancePermission]
 
 
+# Define Context type
+class Context(TypedDict, total=False):
+    account: Optional[str]
+
+
 # Define Configuration type
 class Configuration(TypedDict, total=False):
     actions: Optional[Actions]
+    context: Optional[Context]
 
 
 def is_tool_allowed(tool, configuration):

--- a/python/stripe_agent_toolkit/crewai/toolkit.py
+++ b/python/stripe_agent_toolkit/crewai/toolkit.py
@@ -1,6 +1,6 @@
 """Stripe Agent Toolkit."""
 
-from typing import List
+from typing import List, Optional
 from pydantic import PrivateAttr
 
 from ..api import StripeAPI
@@ -12,10 +12,14 @@ from .tool import StripeTool
 class StripeAgentToolkit:
     _tools: List = PrivateAttr(default=[])
 
-    def __init__(self, secret_key: str, configuration: Configuration = None):
+    def __init__(
+        self, secret_key: str, configuration: Optional[Configuration] = None
+    ):
         super().__init__()
 
-        stripe_api = StripeAPI(secret_key=secret_key)
+        context = configuration.get("context") if configuration else None
+
+        stripe_api = StripeAPI(secret_key=secret_key, context=context)
 
         filtered_tools = [
             tool for tool in tools if is_tool_allowed(tool, configuration)

--- a/python/stripe_agent_toolkit/langchain/toolkit.py
+++ b/python/stripe_agent_toolkit/langchain/toolkit.py
@@ -1,21 +1,25 @@
 """Stripe Agent Toolkit."""
 
-from typing import List
+from typing import List, Optional
 from pydantic import PrivateAttr
 
 from ..api import StripeAPI
 from ..tools import tools
-from ..configuration import Configuration, is_tool_allowed
+from ..configuration import Configuration, Context, is_tool_allowed
 from .tool import StripeTool
 
 
 class StripeAgentToolkit:
     _tools: List = PrivateAttr(default=[])
 
-    def __init__(self, secret_key: str, configuration: Configuration = None):
+    def __init__(
+        self, secret_key: str, configuration: Optional[Configuration] = None
+    ):
         super().__init__()
 
-        stripe_api = StripeAPI(secret_key=secret_key)
+        context = configuration.get("context") if configuration else None
+
+        stripe_api = StripeAPI(secret_key=secret_key, context=context)
 
         filtered_tools = [
             tool for tool in tools if is_tool_allowed(tool, configuration)

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -25,7 +25,32 @@ class TestStripeFunctions(unittest.TestCase):
             )
 
             result = create_customer(
+                context={}, name="Test User", email="test@example.com"
+            )
+
+            mock_function.assert_called_with(
                 name="Test User", email="test@example.com"
+            )
+
+            self.assertEqual(result, {"id": mock_customer["id"]})
+
+    def test_create_customer_with_context(self):
+        with mock.patch("stripe.Customer.create") as mock_function:
+            mock_customer = {"id": "cus_123"}
+            mock_function.return_value = stripe.Customer.construct_from(
+                mock_customer, "sk_test_123"
+            )
+
+            result = create_customer(
+                context={"account": "acct_123"},
+                name="Test User",
+                email="test@example.com",
+            )
+
+            mock_function.assert_called_with(
+                name="Test User",
+                email="test@example.com",
+                stripe_account="acct_123",
             )
 
             self.assertEqual(result, {"id": mock_customer["id"]})
@@ -61,7 +86,49 @@ class TestStripeFunctions(unittest.TestCase):
                 "sk_test_123",
             )
 
-            result = list_customers()
+            result = list_customers(context={})
+
+            mock_function.assert_called_with()
+
+            self.assertEqual(result, mock_customers)
+
+    def test_list_customers_with_context(self):
+        with mock.patch("stripe.Customer.list") as mock_function:
+            mock_customers = [{"id": "cus_123"}, {"id": "cus_456"}]
+
+            mock_function.return_value = stripe.ListObject.construct_from(
+                {
+                    "object": "list",
+                    "data": [
+                        stripe.Customer.construct_from(
+                            {
+                                "id": "cus_123",
+                                "email": "customer1@example.com",
+                                "name": "Customer One",
+                            },
+                            "sk_test_123",
+                        ),
+                        stripe.Customer.construct_from(
+                            {
+                                "id": "cus_456",
+                                "email": "customer2@example.com",
+                                "name": "Customer Two",
+                            },
+                            "sk_test_123",
+                        ),
+                    ],
+                    "has_more": False,
+                    "url": "/v1/customers",
+                },
+                "sk_test_123",
+            )
+
+            result = list_customers(context={"account": "acct_123"})
+
+            mock_function.assert_called_with(
+                stripe_account="acct_123",
+            )
+
             self.assertEqual(result, mock_customers)
 
     def test_create_product(self):
@@ -71,7 +138,28 @@ class TestStripeFunctions(unittest.TestCase):
                 mock_product, "sk_test_123"
             )
 
-            result = create_product(name="Test Product")
+            result = create_product(context={}, name="Test Product")
+
+            mock_function.assert_called_with(
+                name="Test Product",
+            )
+
+            self.assertEqual(result, {"id": mock_product["id"]})
+
+    def test_create_product_with_context(self):
+        with mock.patch("stripe.Product.create") as mock_function:
+            mock_product = {"id": "prod_123"}
+            mock_function.return_value = stripe.Product.construct_from(
+                mock_product, "sk_test_123"
+            )
+
+            result = create_product(
+                context={"account": "acct_123"}, name="Test Product"
+            )
+
+            mock_function.assert_called_with(
+                name="Test Product", stripe_account="acct_123"
+            )
 
             self.assertEqual(result, {"id": mock_product["id"]})
 
@@ -107,7 +195,10 @@ class TestStripeFunctions(unittest.TestCase):
                 "sk_test_123",
             )
 
-            result = list_products()
+            result = list_products(context={})
+
+            mock_function.assert_called_with()
+
             self.assertEqual(result, mock_products)
 
     def test_create_price(self):
@@ -118,7 +209,39 @@ class TestStripeFunctions(unittest.TestCase):
             )
 
             result = create_price(
-                product="prod_123", currency="usd", unit_amount=1000
+                context={},
+                product="prod_123",
+                currency="usd",
+                unit_amount=1000,
+            )
+
+            mock_function.assert_called_with(
+                product="prod_123",
+                currency="usd",
+                unit_amount=1000,
+            )
+
+            self.assertEqual(result, {"id": mock_price["id"]})
+
+    def test_create_price_with_context(self):
+        with mock.patch("stripe.Price.create") as mock_function:
+            mock_price = {"id": "price_123"}
+            mock_function.return_value = stripe.Price.construct_from(
+                mock_price, "sk_test_123"
+            )
+
+            result = create_price(
+                context={"account": "acct_123"},
+                product="prod_123",
+                currency="usd",
+                unit_amount=1000,
+            )
+
+            mock_function.assert_called_with(
+                product="prod_123",
+                currency="usd",
+                unit_amount=1000,
+                stripe_account="acct_123",
             )
 
             self.assertEqual(result, {"id": mock_price["id"]})
@@ -155,7 +278,47 @@ class TestStripeFunctions(unittest.TestCase):
                 "sk_test_123",
             )
 
-            result = list_prices()
+            result = list_prices({})
+
+            mock_function.assert_called_with()
+
+            self.assertEqual(result, mock_prices)
+
+    def test_list_prices_with_context(self):
+        with mock.patch("stripe.Price.list") as mock_function:
+            mock_prices = [
+                {"id": "price_123", "product": "prod_123"},
+                {"id": "price_456", "product": "prod_456"},
+            ]
+
+            mock_function.return_value = stripe.ListObject.construct_from(
+                {
+                    "object": "list",
+                    "data": [
+                        stripe.Price.construct_from(
+                            {
+                                "id": "price_123",
+                                "product": "prod_123",
+                            },
+                            "sk_test_123",
+                        ),
+                        stripe.Price.construct_from(
+                            {
+                                "id": "price_456",
+                                "product": "prod_456",
+                            },
+                            "sk_test_123",
+                        ),
+                    ],
+                    "has_more": False,
+                    "url": "/v1/prices",
+                },
+                "sk_test_123",
+            )
+
+            result = list_prices({"account": "acct_123"})
+
+            mock_function.assert_called_with(stripe_account="acct_123")
 
             self.assertEqual(result, mock_prices)
 
@@ -166,7 +329,31 @@ class TestStripeFunctions(unittest.TestCase):
                 mock_payment_link, "sk_test_123"
             )
 
-            result = create_payment_link(price="price_123", quantity=1)
+            result = create_payment_link(
+                context={}, price="price_123", quantity=1
+            )
+
+            mock_function.assert_called_with(
+                line_items=[{"price": "price_123", "quantity": 1}],
+            )
+
+            self.assertEqual(result, mock_payment_link)
+
+    def test_create_payment_link_with_context(self):
+        with mock.patch("stripe.PaymentLink.create") as mock_function:
+            mock_payment_link = {"id": "pl_123", "url": "https://example.com"}
+            mock_function.return_value = stripe.PaymentLink.construct_from(
+                mock_payment_link, "sk_test_123"
+            )
+
+            result = create_payment_link(
+                context={"account": "acct_123"}, price="price_123", quantity=1
+            )
+
+            mock_function.assert_called_with(
+                line_items=[{"price": "price_123", "quantity": 1}],
+                stripe_account="acct_123",
+            )
 
             self.assertEqual(result, mock_payment_link)
 
@@ -183,7 +370,47 @@ class TestStripeFunctions(unittest.TestCase):
                 mock_invoice, "sk_test_123"
             )
 
-            result = create_invoice(customer="cus_123")
+            result = create_invoice(context={}, customer="cus_123")
+
+            mock_function.assert_called_with(
+                customer="cus_123",
+                collection_method="send_invoice",
+                days_until_due=30,
+            )
+
+            self.assertEqual(
+                result,
+                {
+                    "id": mock_invoice["id"],
+                    "hosted_invoice_url": mock_invoice["hosted_invoice_url"],
+                    "customer": mock_invoice["customer"],
+                    "status": mock_invoice["status"],
+                },
+            )
+
+    def test_create_invoice_with_context(self):
+        with mock.patch("stripe.Invoice.create") as mock_function:
+            mock_invoice = {
+                "id": "in_123",
+                "hosted_invoice_url": "https://example.com",
+                "customer": "cus_123",
+                "status": "open",
+            }
+
+            mock_function.return_value = stripe.Invoice.construct_from(
+                mock_invoice, "sk_test_123"
+            )
+
+            result = create_invoice(
+                context={"account": "acct_123"}, customer="cus_123"
+            )
+
+            mock_function.assert_called_with(
+                customer="cus_123",
+                collection_method="send_invoice",
+                days_until_due=30,
+                stripe_account="acct_123",
+            )
 
             self.assertEqual(
                 result,
@@ -203,7 +430,43 @@ class TestStripeFunctions(unittest.TestCase):
             )
 
             result = create_invoice_item(
+                context={},
+                customer="cus_123",
+                price="price_123",
+                invoice="in_123",
+            )
+
+            mock_function.assert_called_with(
                 customer="cus_123", price="price_123", invoice="in_123"
+            )
+
+            self.assertEqual(
+                result,
+                {
+                    "id": mock_invoice_item["id"],
+                    "invoice": mock_invoice_item["invoice"],
+                },
+            )
+
+    def test_create_invoice_item_with_context(self):
+        with mock.patch("stripe.InvoiceItem.create") as mock_function:
+            mock_invoice_item = {"id": "ii_123", "invoice": "in_123"}
+            mock_function.return_value = stripe.InvoiceItem.construct_from(
+                mock_invoice_item, "sk_test_123"
+            )
+
+            result = create_invoice_item(
+                context={"account": "acct_123"},
+                customer="cus_123",
+                price="price_123",
+                invoice="in_123",
+            )
+
+            mock_function.assert_called_with(
+                customer="cus_123",
+                price="price_123",
+                invoice="in_123",
+                stripe_account="acct_123",
             )
 
             self.assertEqual(
@@ -227,7 +490,40 @@ class TestStripeFunctions(unittest.TestCase):
                 mock_invoice, "sk_test_123"
             )
 
-            result = finalize_invoice(invoice="in_123")
+            result = finalize_invoice(context={}, invoice="in_123")
+
+            mock_function.assert_called_with(invoice="in_123")
+
+            self.assertEqual(
+                result,
+                {
+                    "id": mock_invoice["id"],
+                    "hosted_invoice_url": mock_invoice["hosted_invoice_url"],
+                    "customer": mock_invoice["customer"],
+                    "status": mock_invoice["status"],
+                },
+            )
+
+    def test_finalize_invoice_with_context(self):
+        with mock.patch("stripe.Invoice.finalize_invoice") as mock_function:
+            mock_invoice = {
+                "id": "in_123",
+                "hosted_invoice_url": "https://example.com",
+                "customer": "cus_123",
+                "status": "open",
+            }
+
+            mock_function.return_value = stripe.Invoice.construct_from(
+                mock_invoice, "sk_test_123"
+            )
+
+            result = finalize_invoice(
+                context={"account": "acct_123"}, invoice="in_123"
+            )
+
+            mock_function.assert_called_with(
+                invoice="in_123", stripe_account="acct_123"
+            )
 
             self.assertEqual(
                 result,
@@ -247,7 +543,23 @@ class TestStripeFunctions(unittest.TestCase):
                 mock_balance, "sk_test_123"
             )
 
-            result = retrieve_balance()
+            result = retrieve_balance(context={})
+
+            mock_function.assert_called_with()
+
+            self.assertEqual(result, mock_balance)
+
+    def test_retrieve_balance_with_context(self):
+        with mock.patch("stripe.Balance.retrieve") as mock_function:
+            mock_balance = {"available": [{"amount": 1000, "currency": "usd"}]}
+
+            mock_function.return_value = stripe.Balance.construct_from(
+                mock_balance, "sk_test_123"
+            )
+
+            result = retrieve_balance(context={"account": "acct_123"})
+
+            mock_function.assert_called_with(stripe_account="acct_123")
 
             self.assertEqual(result, mock_balance)
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -65,9 +65,9 @@ const stripeAgentToolkit = new StripeAgentToolkit({
   configuration: {
     context: {
       account: 'acct_123',
-    }
-  }
-})
+    },
+  },
+});
 ```
 
 ### Metered billing

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -55,6 +55,21 @@ const agentExecutor = new AgentExecutor({
 });
 ```
 
+#### Context
+
+In some cases you will want to provide values that serve as defaults when making requests. Currently, the `account` context value enables you to make API calls for your [connected accounts](https://docs.stripe.com/connect/authentication).
+
+```typescript
+const stripeAgentToolkit = new StripeAgentToolkit({
+  secretKey: process.env.STRIPE_SECRET_KEY!,
+  configuration: {
+    context: {
+      account: 'acct_123',
+    }
+  }
+})
+```
+
 ### Metered billing
 
 For Vercel's AI SDK, you can use middleware to submit billing events for usage. All that is required is the customer ID and the input/output meters to bill.

--- a/typescript/examples/langchain/index.ts
+++ b/typescript/examples/langchain/index.ts
@@ -1,4 +1,4 @@
-import {StripeAgentToolkit} from '../../src/langchain';
+import {StripeAgentToolkit} from '@stripe/agent-toolkit/langchain';
 import {ChatOpenAI} from '@langchain/openai';
 import type {ChatPromptTemplate} from '@langchain/core/prompts';
 import {pull} from 'langchain/hub';

--- a/typescript/examples/langchain/index.ts
+++ b/typescript/examples/langchain/index.ts
@@ -1,4 +1,4 @@
-import {StripeAgentToolkit} from '@stripe/agent-toolkit/langchain';
+import {StripeAgentToolkit} from '../../src/langchain';
 import {ChatOpenAI} from '@langchain/openai';
 import type {ChatPromptTemplate} from '@langchain/core/prompts';
 import {pull} from 'langchain/hub';

--- a/typescript/src/ai-sdk/toolkit.ts
+++ b/typescript/src/ai-sdk/toolkit.ts
@@ -31,7 +31,7 @@ class StripeAgentToolkit {
     secretKey: string;
     configuration: Configuration;
   }) {
-    this._stripe = new StripeAPI(secretKey);
+    this._stripe = new StripeAPI(secretKey, configuration.context);
     this.tools = {};
 
     const filteredTools = tools.filter((tool) =>

--- a/typescript/src/langchain/toolkit.ts
+++ b/typescript/src/langchain/toolkit.ts
@@ -16,7 +16,7 @@ class StripeAgentToolkit implements BaseToolkit {
     secretKey: string;
     configuration: Configuration;
   }) {
-    this._stripe = new StripeAPI(secretKey);
+    this._stripe = new StripeAPI(secretKey, configuration.context);
 
     const filteredTools = tools.filter((tool) =>
       isToolAllowed(tool, configuration)

--- a/typescript/src/shared/api.ts
+++ b/typescript/src/shared/api.ts
@@ -13,10 +13,14 @@ import {
   retrieveBalance,
 } from './functions';
 
+import type {Context} from './configuration';
+
 class StripeAPI {
   stripe: Stripe;
 
-  constructor(secretKey: string) {
+  context: Context;
+
+  constructor(secretKey: string, context: Context) {
     const stripeClient = new Stripe(secretKey, {
       appInfo: {
         name: 'stripe-agent-toolkit-typescript',
@@ -25,6 +29,7 @@ class StripeAPI {
       },
     });
     this.stripe = stripeClient;
+    this.context = context;
   }
 
   async createMeterEvent({
@@ -47,37 +52,59 @@ class StripeAPI {
 
   async run(method: string, arg: any) {
     if (method === 'create_customer') {
-      const output = JSON.stringify(await createCustomer(this.stripe, arg));
+      const output = JSON.stringify(
+        await createCustomer(this.stripe, this.context, arg)
+      );
       return output;
     } else if (method === 'list_customers') {
-      const output = JSON.stringify(await listCustomers(this.stripe, arg));
+      const output = JSON.stringify(
+        await listCustomers(this.stripe, this.context, arg)
+      );
       return output;
     } else if (method === 'create_product') {
-      const output = JSON.stringify(await createProduct(this.stripe, arg));
+      const output = JSON.stringify(
+        await createProduct(this.stripe, this.context, arg)
+      );
       return output;
     } else if (method === 'list_products') {
-      const output = JSON.stringify(await listProducts(this.stripe, arg));
+      const output = JSON.stringify(
+        await listProducts(this.stripe, this.context, arg)
+      );
       return output;
     } else if (method === 'create_price') {
-      const output = JSON.stringify(await createPrice(this.stripe, arg));
+      const output = JSON.stringify(
+        await createPrice(this.stripe, this.context, arg)
+      );
       return output;
     } else if (method === 'list_prices') {
-      const output = JSON.stringify(await listPrices(this.stripe, arg));
+      const output = JSON.stringify(
+        await listPrices(this.stripe, this.context, arg)
+      );
       return output;
     } else if (method === 'create_payment_link') {
-      const output = JSON.stringify(await createPaymentLink(this.stripe, arg));
+      const output = JSON.stringify(
+        await createPaymentLink(this.stripe, this.context, arg)
+      );
       return output;
     } else if (method === 'create_invoice') {
-      const output = JSON.stringify(await createInvoice(this.stripe, arg));
+      const output = JSON.stringify(
+        await createInvoice(this.stripe, this.context, arg)
+      );
       return output;
     } else if (method === 'create_invoice_item') {
-      const output = JSON.stringify(await createInvoiceItem(this.stripe, arg));
+      const output = JSON.stringify(
+        await createInvoiceItem(this.stripe, this.context, arg)
+      );
       return output;
     } else if (method === 'finalize_invoice') {
-      const output = JSON.stringify(await finalizeInvoice(this.stripe, arg));
+      const output = JSON.stringify(
+        await finalizeInvoice(this.stripe, this.context, arg)
+      );
       return output;
     } else if (method === 'retrieve_balance') {
-      const output = JSON.stringify(await retrieveBalance(this.stripe, arg));
+      const output = JSON.stringify(
+        await retrieveBalance(this.stripe, this.context, arg)
+      );
       return output;
     } else {
       throw new Error('Invalid method ' + method);

--- a/typescript/src/shared/api.ts
+++ b/typescript/src/shared/api.ts
@@ -20,7 +20,7 @@ class StripeAPI {
 
   context: Context;
 
-  constructor(secretKey: string, context: Context) {
+  constructor(secretKey: string, context?: Context) {
     const stripeClient = new Stripe(secretKey, {
       appInfo: {
         name: 'stripe-agent-toolkit-typescript',
@@ -29,7 +29,7 @@ class StripeAPI {
       },
     });
     this.stripe = stripeClient;
-    this.context = context;
+    this.context = context || {};
   }
 
   async createMeterEvent({
@@ -41,13 +41,16 @@ class StripeAPI {
     customer: string;
     value: string;
   }) {
-    await this.stripe.billing.meterEvents.create({
-      event_name: event,
-      payload: {
-        stripe_customer_id: customer,
-        value: value,
+    await this.stripe.billing.meterEvents.create(
+      {
+        event_name: event,
+        payload: {
+          stripe_customer_id: customer,
+          value: value,
+        },
       },
-    });
+      this.context.account ? {stripeAccount: this.context.account} : undefined
+    );
   }
 
   async run(method: string, arg: any) {

--- a/typescript/src/shared/configuration.ts
+++ b/typescript/src/shared/configuration.ts
@@ -24,10 +24,18 @@ export type Actions = {
   };
 };
 
+// Context are settings that are applied to all requests made by the integration.
+export type Context = {
+  // Account is a Stripe Connected Account ID. If set, the integration will
+  // make requests for this Account.
+  account?: string;
+};
+
 // Configuration provides various settings and options for the integration
 // to tune and manage how it behaves.
 export type Configuration = {
   actions?: Actions;
+  context?: Context;
 };
 
 export const isToolAllowed = (

--- a/typescript/src/shared/functions.ts
+++ b/typescript/src/shared/functions.ts
@@ -13,13 +13,19 @@ import {
   finalizeInvoiceParameters,
   retrieveBalanceParameters,
 } from './parameters';
+import type {Context} from './configuration';
 
 export const createCustomer = async (
   stripe: Stripe,
+  context: Context,
   params: z.infer<typeof createCustomerParameters>
 ) => {
   try {
-    const customer = await stripe.customers.create(params);
+    const customer = await stripe.customers.create(
+      params,
+      context.account ? {stripeAccount: context.account} : undefined
+    );
+
     return {id: customer.id};
   } catch (error) {
     return 'Failed to create customer';
@@ -28,10 +34,15 @@ export const createCustomer = async (
 
 export const listCustomers = async (
   stripe: Stripe,
+  context: Context,
   params: z.infer<typeof listCustomersParameters>
 ) => {
   try {
-    const customers = await stripe.customers.list(params);
+    const customers = await stripe.customers.list(
+      params,
+      context.account ? {stripeAccount: context.account} : undefined
+    );
+
     return customers.data.map((customer) => ({id: customer.id}));
   } catch (error) {
     return 'Failed to list customers';
@@ -40,10 +51,15 @@ export const listCustomers = async (
 
 export const createProduct = async (
   stripe: Stripe,
+  context: Context,
   params: z.infer<typeof createProductParameters>
 ) => {
   try {
-    const product = await stripe.products.create(params);
+    const product = await stripe.products.create(
+      params,
+      context.account ? {stripeAccount: context.account} : undefined
+    );
+
     return product;
   } catch (error) {
     return 'Failed to create product';
@@ -52,10 +68,15 @@ export const createProduct = async (
 
 export const listProducts = async (
   stripe: Stripe,
+  context: Context,
   params: z.infer<typeof listProductsParameters>
 ) => {
   try {
-    const products = await stripe.products.list(params);
+    const products = await stripe.products.list(
+      params,
+      context.account ? {stripeAccount: context.account} : undefined
+    );
+
     return products.data;
   } catch (error) {
     return 'Failed to list products';
@@ -64,10 +85,15 @@ export const listProducts = async (
 
 export const createPrice = async (
   stripe: Stripe,
+  context: Context,
   params: z.infer<typeof createPriceParameters>
 ) => {
   try {
-    const price = await stripe.prices.create(params);
+    const price = await stripe.prices.create(
+      params,
+      context.account ? {stripeAccount: context.account} : undefined
+    );
+
     return price;
   } catch (error) {
     return 'Failed to create price';
@@ -76,10 +102,15 @@ export const createPrice = async (
 
 export const listPrices = async (
   stripe: Stripe,
+  context: Context,
   params: z.infer<typeof listPricesParameters>
 ) => {
   try {
-    const prices = await stripe.prices.list(params);
+    const prices = await stripe.prices.list(
+      params,
+      context.account ? {stripeAccount: context.account} : undefined
+    );
+
     return prices.data;
   } catch (error) {
     return 'Failed to list prices';
@@ -88,12 +119,17 @@ export const listPrices = async (
 
 export const createPaymentLink = async (
   stripe: Stripe,
+  context: Context,
   params: z.infer<typeof createPaymentLinkParameters>
 ) => {
   try {
-    const paymentLink = await stripe.paymentLinks.create({
-      line_items: [params],
-    });
+    const paymentLink = await stripe.paymentLinks.create(
+      {
+        line_items: [params],
+      },
+      context.account ? {stripeAccount: context.account} : undefined
+    );
+
     return {id: paymentLink.id, url: paymentLink.url};
   } catch (error) {
     return 'Failed to create payment link';
@@ -102,10 +138,15 @@ export const createPaymentLink = async (
 
 export const createInvoice = async (
   stripe: Stripe,
+  context: Context,
   params: z.infer<typeof createInvoiceParameters>
 ) => {
   try {
-    const invoice = await stripe.invoices.create(params);
+    const invoice = await stripe.invoices.create(
+      params,
+      context.account ? {stripeAccount: context.account} : undefined
+    );
+
     return {
       id: invoice.id,
       url: invoice.hosted_invoice_url,
@@ -119,10 +160,15 @@ export const createInvoice = async (
 
 export const createInvoiceItem = async (
   stripe: Stripe,
+  context: Context,
   params: z.infer<typeof createInvoiceItemParameters>
 ) => {
   try {
-    const invoiceItem = await stripe.invoiceItems.create(params);
+    const invoiceItem = await stripe.invoiceItems.create(
+      params,
+      context.account ? {stripeAccount: context.account} : undefined
+    );
+
     return {
       id: invoiceItem.id,
       invoice: invoiceItem.invoice,
@@ -134,10 +180,15 @@ export const createInvoiceItem = async (
 
 export const finalizeInvoice = async (
   stripe: Stripe,
+  context: Context,
   params: z.infer<typeof finalizeInvoiceParameters>
 ) => {
   try {
-    const invoice = await stripe.invoices.finalizeInvoice(params.invoice);
+    const invoice = await stripe.invoices.finalizeInvoice(
+      params.invoice,
+      context.account ? {stripeAccount: context.account} : undefined
+    );
+
     return {
       id: invoice.id,
       url: invoice.hosted_invoice_url,
@@ -151,10 +202,15 @@ export const finalizeInvoice = async (
 
 export const retrieveBalance = async (
   stripe: Stripe,
+  context: Context,
   params: z.infer<typeof retrieveBalanceParameters>
 ) => {
   try {
-    const balance = await stripe.balance.retrieve(params);
+    const balance = await stripe.balance.retrieve(
+      params,
+      context.account ? {stripeAccount: context.account} : undefined
+    );
+
     return balance;
   } catch (error) {
     return 'Failed to retrieve balance';

--- a/typescript/src/test/shared/functions.test.ts
+++ b/typescript/src/test/shared/functions.test.ts
@@ -54,12 +54,35 @@ describe('createCustomer', () => {
       name: 'Test User',
     };
 
+    const globals = {};
+
     const mockCustomer = {id: 'cus_123456', email: 'test@example.com'};
     stripe.customers.create.mockResolvedValue(mockCustomer);
 
-    const result = await createCustomer(stripe, params);
+    const result = await createCustomer(stripe, globals, params);
 
-    expect(stripe.customers.create).toHaveBeenCalledWith(params);
+    expect(stripe.customers.create).toHaveBeenCalledWith(params, undefined);
+    expect(result).toEqual({id: mockCustomer.id});
+  });
+
+  it('should specify the connected account if included in globals', async () => {
+    const params = {
+      email: 'test@example.com',
+      name: 'Test User',
+    };
+
+    const globals = {
+      account: 'acct_123456',
+    };
+
+    const mockCustomer = {id: 'cus_123456', email: 'test@example.com'};
+    stripe.customers.create.mockResolvedValue(mockCustomer);
+
+    const result = await createCustomer(stripe, globals, params);
+
+    expect(stripe.customers.create).toHaveBeenCalledWith(params, {
+      stripeAccount: globals.account,
+    });
     expect(result).toEqual({id: mockCustomer.id});
   });
 });
@@ -71,10 +94,34 @@ describe('listCustomers', () => {
       {id: 'cus_789012', email: 'test2@example.com'},
     ];
 
-    stripe.customers.list.mockResolvedValue({data: mockCustomers});
-    const result = await listCustomers(stripe, {});
+    const globals = {};
 
-    expect(stripe.customers.list).toHaveBeenCalledWith({});
+    stripe.customers.list.mockResolvedValue({data: mockCustomers});
+    const result = await listCustomers(stripe, globals, {});
+
+    expect(stripe.customers.list).toHaveBeenCalledWith({}, undefined);
+    expect(result).toEqual(mockCustomers.map(({id}) => ({id})));
+  });
+
+  it('should specify the connected account if included in globals', async () => {
+    const mockCustomers = [
+      {id: 'cus_123456', email: 'test1@example.com'},
+      {id: 'cus_789012', email: 'test2@example.com'},
+    ];
+
+    const globals = {
+      account: 'acct_123456',
+    };
+
+    stripe.customers.list.mockResolvedValue({data: mockCustomers});
+    const result = await listCustomers(stripe, globals, {});
+
+    expect(stripe.customers.list).toHaveBeenCalledWith(
+      {},
+      {
+        stripeAccount: globals.account,
+      }
+    );
     expect(result).toEqual(mockCustomers.map(({id}) => ({id})));
   });
 });
@@ -85,12 +132,34 @@ describe('createProduct', () => {
       name: 'Test Product',
     };
 
+    const globals = {};
+
     const mockProduct = {id: 'prod_123456', name: 'Test Product'};
     stripe.products.create.mockResolvedValue(mockProduct);
 
-    const result = await createProduct(stripe, params);
+    const result = await createProduct(stripe, globals, params);
 
-    expect(stripe.products.create).toHaveBeenCalledWith(params);
+    expect(stripe.products.create).toHaveBeenCalledWith(params, undefined);
+    expect(result).toEqual(mockProduct);
+  });
+
+  it('should specify the connected account if included in globals', async () => {
+    const params = {
+      name: 'Test Product',
+    };
+
+    const globals = {
+      account: 'acct_123456',
+    };
+
+    const mockProduct = {id: 'prod_123456', name: 'Test Product'};
+    stripe.products.create.mockResolvedValue(mockProduct);
+
+    const result = await createProduct(stripe, globals, params);
+
+    expect(stripe.products.create).toHaveBeenCalledWith(params, {
+      stripeAccount: globals.account,
+    });
     expect(result).toEqual(mockProduct);
   });
 });
@@ -102,10 +171,34 @@ describe('listProducts', () => {
       {id: 'prod_789012', name: 'Test Product 2'},
     ];
 
-    stripe.products.list.mockResolvedValue({data: mockProducts});
-    const result = await listProducts(stripe, {});
+    const globals = {};
 
-    expect(stripe.products.list).toHaveBeenCalledWith({});
+    stripe.products.list.mockResolvedValue({data: mockProducts});
+    const result = await listProducts(stripe, globals, {});
+
+    expect(stripe.products.list).toHaveBeenCalledWith({}, undefined);
+    expect(result).toEqual(mockProducts);
+  });
+
+  it('should specify the connected account if included in globals', async () => {
+    const mockProducts = [
+      {id: 'prod_123456', name: 'Test Product 1'},
+      {id: 'prod_789012', name: 'Test Product 2'},
+    ];
+
+    const globals = {
+      account: 'acct_123456',
+    };
+
+    stripe.products.list.mockResolvedValue({data: mockProducts});
+    const result = await listProducts(stripe, globals, {});
+
+    expect(stripe.products.list).toHaveBeenCalledWith(
+      {},
+      {
+        stripeAccount: globals.account,
+      }
+    );
     expect(result).toEqual(mockProducts);
   });
 });
@@ -118,12 +211,36 @@ describe('createPrice', () => {
       product: 'prod_123456',
     };
 
+    const globals = {};
+
     const mockPrice = {id: 'price_123456', unit_amount: 1000, currency: 'usd'};
     stripe.prices.create.mockResolvedValue(mockPrice);
 
-    const result = await createPrice(stripe, params);
+    const result = await createPrice(stripe, globals, params);
 
-    expect(stripe.prices.create).toHaveBeenCalledWith(params);
+    expect(stripe.prices.create).toHaveBeenCalledWith(params, undefined);
+    expect(result).toEqual(mockPrice);
+  });
+
+  it('should specify the connected account if included in globals', async () => {
+    const params = {
+      unit_amount: 1000,
+      currency: 'usd',
+      product: 'prod_123456',
+    };
+
+    const globals = {
+      account: 'acct_123456',
+    };
+
+    const mockPrice = {id: 'price_123456', unit_amount: 1000, currency: 'usd'};
+    stripe.prices.create.mockResolvedValue(mockPrice);
+
+    const result = await createPrice(stripe, globals, params);
+
+    expect(stripe.prices.create).toHaveBeenCalledWith(params, {
+      stripeAccount: globals.account,
+    });
     expect(result).toEqual(mockPrice);
   });
 });
@@ -135,10 +252,34 @@ describe('listPrices', () => {
       {id: 'price_789012', unit_amount: 2000, currency: 'usd'},
     ];
 
-    stripe.prices.list.mockResolvedValue({data: mockPrices});
-    const result = await listPrices(stripe, {});
+    const globals = {};
 
-    expect(stripe.prices.list).toHaveBeenCalledWith({});
+    stripe.prices.list.mockResolvedValue({data: mockPrices});
+    const result = await listPrices(stripe, globals, {});
+
+    expect(stripe.prices.list).toHaveBeenCalledWith({}, undefined);
+    expect(result).toEqual(mockPrices);
+  });
+
+  it('should specify the connected account if included in globals', async () => {
+    const mockPrices = [
+      {id: 'price_123456', unit_amount: 1000, currency: 'usd'},
+      {id: 'price_789012', unit_amount: 2000, currency: 'usd'},
+    ];
+
+    const globals = {
+      account: 'acct_123456',
+    };
+
+    stripe.prices.list.mockResolvedValue({data: mockPrices});
+    const result = await listPrices(stripe, globals, {});
+
+    expect(stripe.prices.list).toHaveBeenCalledWith(
+      {},
+      {
+        stripeAccount: globals.account,
+      }
+    );
     expect(result).toEqual(mockPrices);
   });
 });
@@ -159,14 +300,48 @@ describe('createPaymentLink', () => {
       url: 'https://example.com',
     };
 
+    const globals = {};
+
     stripe.paymentLinks.create.mockResolvedValue(mockPaymentLink);
 
-    const result = await createPaymentLink(stripe, {
+    const result = await createPaymentLink(stripe, globals, {
       price: 'price_123456',
       quantity: 1,
     });
 
-    expect(stripe.paymentLinks.create).toHaveBeenCalledWith(params);
+    expect(stripe.paymentLinks.create).toHaveBeenCalledWith(params, undefined);
+    expect(result).toEqual(mockPaymentLink);
+  });
+
+  it('should specify the connected account if included in globals', async () => {
+    const params = {
+      line_items: [
+        {
+          price: 'price_123456',
+          quantity: 1,
+        },
+      ],
+    };
+
+    const mockPaymentLink = {
+      id: 'pl_123456',
+      url: 'https://example.com',
+    };
+
+    const globals = {
+      account: 'acct_123456',
+    };
+
+    stripe.paymentLinks.create.mockResolvedValue(mockPaymentLink);
+
+    const result = await createPaymentLink(stripe, globals, {
+      price: 'price_123456',
+      quantity: 1,
+    });
+
+    expect(stripe.paymentLinks.create).toHaveBeenCalledWith(params, {
+      stripeAccount: globals.account,
+    });
     expect(result).toEqual(mockPaymentLink);
   });
 });
@@ -179,9 +354,36 @@ describe('createInvoice', () => {
     };
 
     const mockInvoice = {id: 'in_123456', customer: 'cus_123456'};
+
+    const globals = {};
+
     stripe.invoices.create.mockResolvedValue(mockInvoice);
-    const result = await createInvoice(stripe, params);
-    expect(stripe.invoices.create).toHaveBeenCalledWith(params);
+
+    const result = await createInvoice(stripe, globals, params);
+
+    expect(stripe.invoices.create).toHaveBeenCalledWith(params, undefined);
+    expect(result).toEqual(mockInvoice);
+  });
+
+  it('should specify the connected account if included in globals', async () => {
+    const params = {
+      customer: 'cus_123456',
+      items: [{price: 'price_123456', quantity: 1}],
+    };
+
+    const mockInvoice = {id: 'in_123456', customer: 'cus_123456'};
+
+    const globals = {
+      account: 'acct_123456',
+    };
+
+    stripe.invoices.create.mockResolvedValue(mockInvoice);
+
+    const result = await createInvoice(stripe, globals, params);
+
+    expect(stripe.invoices.create).toHaveBeenCalledWith(params, {
+      stripeAccount: globals.account,
+    });
     expect(result).toEqual(mockInvoice);
   });
 });
@@ -189,10 +391,38 @@ describe('createInvoice', () => {
 describe('finalizeInvoice', () => {
   it('should finalize an invoice and return it', async () => {
     const invoiceId = 'in_123456';
+
     const mockInvoice = {id: invoiceId, customer: 'cus_123456'};
+
+    const globals = {};
+
     stripe.invoices.finalizeInvoice.mockResolvedValue(mockInvoice);
-    const result = await finalizeInvoice(stripe, {invoice: invoiceId});
-    expect(stripe.invoices.finalizeInvoice).toHaveBeenCalledWith(invoiceId);
+
+    const result = await finalizeInvoice(stripe, globals, {invoice: invoiceId});
+
+    expect(stripe.invoices.finalizeInvoice).toHaveBeenCalledWith(
+      invoiceId,
+      undefined
+    );
+    expect(result).toEqual(mockInvoice);
+  });
+
+  it('should specify the connected account if included in globals', async () => {
+    const invoiceId = 'in_123456';
+
+    const mockInvoice = {id: invoiceId, customer: 'cus_123456'};
+
+    const globals = {
+      account: 'acct_123456',
+    };
+
+    stripe.invoices.finalizeInvoice.mockResolvedValue(mockInvoice);
+
+    const result = await finalizeInvoice(stripe, globals, {invoice: invoiceId});
+
+    expect(stripe.invoices.finalizeInvoice).toHaveBeenCalledWith(invoiceId, {
+      stripeAccount: globals.account,
+    });
     expect(result).toEqual(mockInvoice);
   });
 });
@@ -206,9 +436,37 @@ describe('createInvoiceItem', () => {
     };
 
     const mockInvoiceItem = {id: 'ii_123456', invoice: 'in_123456'};
+
+    const globals = {};
+
     stripe.invoiceItems.create.mockResolvedValue(mockInvoiceItem);
-    const result = await createInvoiceItem(stripe, params);
-    expect(stripe.invoiceItems.create).toHaveBeenCalledWith(params);
+
+    const result = await createInvoiceItem(stripe, globals, params);
+
+    expect(stripe.invoiceItems.create).toHaveBeenCalledWith(params, undefined);
+    expect(result).toEqual(mockInvoiceItem);
+  });
+
+  it('should specify the connected account if included in globals', async () => {
+    const params = {
+      customer: 'cus_123456',
+      price: 'price_123456',
+      invoice: 'in_123456',
+    };
+
+    const mockInvoiceItem = {id: 'ii_123456', invoice: 'in_123456'};
+
+    const globals = {
+      account: 'acct_123456',
+    };
+
+    stripe.invoiceItems.create.mockResolvedValue(mockInvoiceItem);
+
+    const result = await createInvoiceItem(stripe, globals, params);
+
+    expect(stripe.invoiceItems.create).toHaveBeenCalledWith(params, {
+      stripeAccount: globals.account,
+    });
     expect(result).toEqual(mockInvoiceItem);
   });
 });
@@ -216,9 +474,34 @@ describe('createInvoiceItem', () => {
 describe('retrieveBalance', () => {
   it('should retrieve the balance and return it', async () => {
     const mockBalance = {available: [{amount: 1000, currency: 'usd'}]};
+
+    const globals = {};
+
     stripe.balance.retrieve.mockResolvedValue(mockBalance);
-    const result = await retrieveBalance(stripe, {});
-    expect(stripe.balance.retrieve).toHaveBeenCalled();
+
+    const result = await retrieveBalance(stripe, globals, {});
+
+    expect(stripe.balance.retrieve).toHaveBeenCalledWith({}, undefined);
+    expect(result).toEqual(mockBalance);
+  });
+
+  it('should specify the connected account if included in globals', async () => {
+    const mockBalance = {available: [{amount: 1000, currency: 'usd'}]};
+
+    const globals = {
+      account: 'acct_123456',
+    };
+
+    stripe.balance.retrieve.mockResolvedValue(mockBalance);
+
+    const result = await retrieveBalance(stripe, globals, {});
+
+    expect(stripe.balance.retrieve).toHaveBeenCalledWith(
+      {},
+      {
+        stripeAccount: globals.account,
+      }
+    );
     expect(result).toEqual(mockBalance);
   });
 });

--- a/typescript/src/test/shared/functions.test.ts
+++ b/typescript/src/test/shared/functions.test.ts
@@ -54,34 +54,34 @@ describe('createCustomer', () => {
       name: 'Test User',
     };
 
-    const globals = {};
+    const context = {};
 
     const mockCustomer = {id: 'cus_123456', email: 'test@example.com'};
     stripe.customers.create.mockResolvedValue(mockCustomer);
 
-    const result = await createCustomer(stripe, globals, params);
+    const result = await createCustomer(stripe, context, params);
 
     expect(stripe.customers.create).toHaveBeenCalledWith(params, undefined);
     expect(result).toEqual({id: mockCustomer.id});
   });
 
-  it('should specify the connected account if included in globals', async () => {
+  it('should specify the connected account if included in context', async () => {
     const params = {
       email: 'test@example.com',
       name: 'Test User',
     };
 
-    const globals = {
+    const context = {
       account: 'acct_123456',
     };
 
     const mockCustomer = {id: 'cus_123456', email: 'test@example.com'};
     stripe.customers.create.mockResolvedValue(mockCustomer);
 
-    const result = await createCustomer(stripe, globals, params);
+    const result = await createCustomer(stripe, context, params);
 
     expect(stripe.customers.create).toHaveBeenCalledWith(params, {
-      stripeAccount: globals.account,
+      stripeAccount: context.account,
     });
     expect(result).toEqual({id: mockCustomer.id});
   });
@@ -94,32 +94,32 @@ describe('listCustomers', () => {
       {id: 'cus_789012', email: 'test2@example.com'},
     ];
 
-    const globals = {};
+    const context = {};
 
     stripe.customers.list.mockResolvedValue({data: mockCustomers});
-    const result = await listCustomers(stripe, globals, {});
+    const result = await listCustomers(stripe, context, {});
 
     expect(stripe.customers.list).toHaveBeenCalledWith({}, undefined);
     expect(result).toEqual(mockCustomers.map(({id}) => ({id})));
   });
 
-  it('should specify the connected account if included in globals', async () => {
+  it('should specify the connected account if included in context', async () => {
     const mockCustomers = [
       {id: 'cus_123456', email: 'test1@example.com'},
       {id: 'cus_789012', email: 'test2@example.com'},
     ];
 
-    const globals = {
+    const context = {
       account: 'acct_123456',
     };
 
     stripe.customers.list.mockResolvedValue({data: mockCustomers});
-    const result = await listCustomers(stripe, globals, {});
+    const result = await listCustomers(stripe, context, {});
 
     expect(stripe.customers.list).toHaveBeenCalledWith(
       {},
       {
-        stripeAccount: globals.account,
+        stripeAccount: context.account,
       }
     );
     expect(result).toEqual(mockCustomers.map(({id}) => ({id})));
@@ -132,33 +132,33 @@ describe('createProduct', () => {
       name: 'Test Product',
     };
 
-    const globals = {};
+    const context = {};
 
     const mockProduct = {id: 'prod_123456', name: 'Test Product'};
     stripe.products.create.mockResolvedValue(mockProduct);
 
-    const result = await createProduct(stripe, globals, params);
+    const result = await createProduct(stripe, context, params);
 
     expect(stripe.products.create).toHaveBeenCalledWith(params, undefined);
     expect(result).toEqual(mockProduct);
   });
 
-  it('should specify the connected account if included in globals', async () => {
+  it('should specify the connected account if included in context', async () => {
     const params = {
       name: 'Test Product',
     };
 
-    const globals = {
+    const context = {
       account: 'acct_123456',
     };
 
     const mockProduct = {id: 'prod_123456', name: 'Test Product'};
     stripe.products.create.mockResolvedValue(mockProduct);
 
-    const result = await createProduct(stripe, globals, params);
+    const result = await createProduct(stripe, context, params);
 
     expect(stripe.products.create).toHaveBeenCalledWith(params, {
-      stripeAccount: globals.account,
+      stripeAccount: context.account,
     });
     expect(result).toEqual(mockProduct);
   });
@@ -171,32 +171,32 @@ describe('listProducts', () => {
       {id: 'prod_789012', name: 'Test Product 2'},
     ];
 
-    const globals = {};
+    const context = {};
 
     stripe.products.list.mockResolvedValue({data: mockProducts});
-    const result = await listProducts(stripe, globals, {});
+    const result = await listProducts(stripe, context, {});
 
     expect(stripe.products.list).toHaveBeenCalledWith({}, undefined);
     expect(result).toEqual(mockProducts);
   });
 
-  it('should specify the connected account if included in globals', async () => {
+  it('should specify the connected account if included in context', async () => {
     const mockProducts = [
       {id: 'prod_123456', name: 'Test Product 1'},
       {id: 'prod_789012', name: 'Test Product 2'},
     ];
 
-    const globals = {
+    const context = {
       account: 'acct_123456',
     };
 
     stripe.products.list.mockResolvedValue({data: mockProducts});
-    const result = await listProducts(stripe, globals, {});
+    const result = await listProducts(stripe, context, {});
 
     expect(stripe.products.list).toHaveBeenCalledWith(
       {},
       {
-        stripeAccount: globals.account,
+        stripeAccount: context.account,
       }
     );
     expect(result).toEqual(mockProducts);
@@ -211,35 +211,35 @@ describe('createPrice', () => {
       product: 'prod_123456',
     };
 
-    const globals = {};
+    const context = {};
 
     const mockPrice = {id: 'price_123456', unit_amount: 1000, currency: 'usd'};
     stripe.prices.create.mockResolvedValue(mockPrice);
 
-    const result = await createPrice(stripe, globals, params);
+    const result = await createPrice(stripe, context, params);
 
     expect(stripe.prices.create).toHaveBeenCalledWith(params, undefined);
     expect(result).toEqual(mockPrice);
   });
 
-  it('should specify the connected account if included in globals', async () => {
+  it('should specify the connected account if included in context', async () => {
     const params = {
       unit_amount: 1000,
       currency: 'usd',
       product: 'prod_123456',
     };
 
-    const globals = {
+    const context = {
       account: 'acct_123456',
     };
 
     const mockPrice = {id: 'price_123456', unit_amount: 1000, currency: 'usd'};
     stripe.prices.create.mockResolvedValue(mockPrice);
 
-    const result = await createPrice(stripe, globals, params);
+    const result = await createPrice(stripe, context, params);
 
     expect(stripe.prices.create).toHaveBeenCalledWith(params, {
-      stripeAccount: globals.account,
+      stripeAccount: context.account,
     });
     expect(result).toEqual(mockPrice);
   });
@@ -252,32 +252,32 @@ describe('listPrices', () => {
       {id: 'price_789012', unit_amount: 2000, currency: 'usd'},
     ];
 
-    const globals = {};
+    const context = {};
 
     stripe.prices.list.mockResolvedValue({data: mockPrices});
-    const result = await listPrices(stripe, globals, {});
+    const result = await listPrices(stripe, context, {});
 
     expect(stripe.prices.list).toHaveBeenCalledWith({}, undefined);
     expect(result).toEqual(mockPrices);
   });
 
-  it('should specify the connected account if included in globals', async () => {
+  it('should specify the connected account if included in context', async () => {
     const mockPrices = [
       {id: 'price_123456', unit_amount: 1000, currency: 'usd'},
       {id: 'price_789012', unit_amount: 2000, currency: 'usd'},
     ];
 
-    const globals = {
+    const context = {
       account: 'acct_123456',
     };
 
     stripe.prices.list.mockResolvedValue({data: mockPrices});
-    const result = await listPrices(stripe, globals, {});
+    const result = await listPrices(stripe, context, {});
 
     expect(stripe.prices.list).toHaveBeenCalledWith(
       {},
       {
-        stripeAccount: globals.account,
+        stripeAccount: context.account,
       }
     );
     expect(result).toEqual(mockPrices);
@@ -300,11 +300,11 @@ describe('createPaymentLink', () => {
       url: 'https://example.com',
     };
 
-    const globals = {};
+    const context = {};
 
     stripe.paymentLinks.create.mockResolvedValue(mockPaymentLink);
 
-    const result = await createPaymentLink(stripe, globals, {
+    const result = await createPaymentLink(stripe, context, {
       price: 'price_123456',
       quantity: 1,
     });
@@ -313,7 +313,7 @@ describe('createPaymentLink', () => {
     expect(result).toEqual(mockPaymentLink);
   });
 
-  it('should specify the connected account if included in globals', async () => {
+  it('should specify the connected account if included in context', async () => {
     const params = {
       line_items: [
         {
@@ -328,19 +328,19 @@ describe('createPaymentLink', () => {
       url: 'https://example.com',
     };
 
-    const globals = {
+    const context = {
       account: 'acct_123456',
     };
 
     stripe.paymentLinks.create.mockResolvedValue(mockPaymentLink);
 
-    const result = await createPaymentLink(stripe, globals, {
+    const result = await createPaymentLink(stripe, context, {
       price: 'price_123456',
       quantity: 1,
     });
 
     expect(stripe.paymentLinks.create).toHaveBeenCalledWith(params, {
-      stripeAccount: globals.account,
+      stripeAccount: context.account,
     });
     expect(result).toEqual(mockPaymentLink);
   });
@@ -355,17 +355,17 @@ describe('createInvoice', () => {
 
     const mockInvoice = {id: 'in_123456', customer: 'cus_123456'};
 
-    const globals = {};
+    const context = {};
 
     stripe.invoices.create.mockResolvedValue(mockInvoice);
 
-    const result = await createInvoice(stripe, globals, params);
+    const result = await createInvoice(stripe, context, params);
 
     expect(stripe.invoices.create).toHaveBeenCalledWith(params, undefined);
     expect(result).toEqual(mockInvoice);
   });
 
-  it('should specify the connected account if included in globals', async () => {
+  it('should specify the connected account if included in context', async () => {
     const params = {
       customer: 'cus_123456',
       items: [{price: 'price_123456', quantity: 1}],
@@ -373,16 +373,16 @@ describe('createInvoice', () => {
 
     const mockInvoice = {id: 'in_123456', customer: 'cus_123456'};
 
-    const globals = {
+    const context = {
       account: 'acct_123456',
     };
 
     stripe.invoices.create.mockResolvedValue(mockInvoice);
 
-    const result = await createInvoice(stripe, globals, params);
+    const result = await createInvoice(stripe, context, params);
 
     expect(stripe.invoices.create).toHaveBeenCalledWith(params, {
-      stripeAccount: globals.account,
+      stripeAccount: context.account,
     });
     expect(result).toEqual(mockInvoice);
   });
@@ -394,11 +394,11 @@ describe('finalizeInvoice', () => {
 
     const mockInvoice = {id: invoiceId, customer: 'cus_123456'};
 
-    const globals = {};
+    const context = {};
 
     stripe.invoices.finalizeInvoice.mockResolvedValue(mockInvoice);
 
-    const result = await finalizeInvoice(stripe, globals, {invoice: invoiceId});
+    const result = await finalizeInvoice(stripe, context, {invoice: invoiceId});
 
     expect(stripe.invoices.finalizeInvoice).toHaveBeenCalledWith(
       invoiceId,
@@ -407,21 +407,21 @@ describe('finalizeInvoice', () => {
     expect(result).toEqual(mockInvoice);
   });
 
-  it('should specify the connected account if included in globals', async () => {
+  it('should specify the connected account if included in context', async () => {
     const invoiceId = 'in_123456';
 
     const mockInvoice = {id: invoiceId, customer: 'cus_123456'};
 
-    const globals = {
+    const context = {
       account: 'acct_123456',
     };
 
     stripe.invoices.finalizeInvoice.mockResolvedValue(mockInvoice);
 
-    const result = await finalizeInvoice(stripe, globals, {invoice: invoiceId});
+    const result = await finalizeInvoice(stripe, context, {invoice: invoiceId});
 
     expect(stripe.invoices.finalizeInvoice).toHaveBeenCalledWith(invoiceId, {
-      stripeAccount: globals.account,
+      stripeAccount: context.account,
     });
     expect(result).toEqual(mockInvoice);
   });
@@ -437,17 +437,17 @@ describe('createInvoiceItem', () => {
 
     const mockInvoiceItem = {id: 'ii_123456', invoice: 'in_123456'};
 
-    const globals = {};
+    const context = {};
 
     stripe.invoiceItems.create.mockResolvedValue(mockInvoiceItem);
 
-    const result = await createInvoiceItem(stripe, globals, params);
+    const result = await createInvoiceItem(stripe, context, params);
 
     expect(stripe.invoiceItems.create).toHaveBeenCalledWith(params, undefined);
     expect(result).toEqual(mockInvoiceItem);
   });
 
-  it('should specify the connected account if included in globals', async () => {
+  it('should specify the connected account if included in context', async () => {
     const params = {
       customer: 'cus_123456',
       price: 'price_123456',
@@ -456,16 +456,16 @@ describe('createInvoiceItem', () => {
 
     const mockInvoiceItem = {id: 'ii_123456', invoice: 'in_123456'};
 
-    const globals = {
+    const context = {
       account: 'acct_123456',
     };
 
     stripe.invoiceItems.create.mockResolvedValue(mockInvoiceItem);
 
-    const result = await createInvoiceItem(stripe, globals, params);
+    const result = await createInvoiceItem(stripe, context, params);
 
     expect(stripe.invoiceItems.create).toHaveBeenCalledWith(params, {
-      stripeAccount: globals.account,
+      stripeAccount: context.account,
     });
     expect(result).toEqual(mockInvoiceItem);
   });
@@ -475,31 +475,31 @@ describe('retrieveBalance', () => {
   it('should retrieve the balance and return it', async () => {
     const mockBalance = {available: [{amount: 1000, currency: 'usd'}]};
 
-    const globals = {};
+    const context = {};
 
     stripe.balance.retrieve.mockResolvedValue(mockBalance);
 
-    const result = await retrieveBalance(stripe, globals, {});
+    const result = await retrieveBalance(stripe, context, {});
 
     expect(stripe.balance.retrieve).toHaveBeenCalledWith({}, undefined);
     expect(result).toEqual(mockBalance);
   });
 
-  it('should specify the connected account if included in globals', async () => {
+  it('should specify the connected account if included in context', async () => {
     const mockBalance = {available: [{amount: 1000, currency: 'usd'}]};
 
-    const globals = {
+    const context = {
       account: 'acct_123456',
     };
 
     stripe.balance.retrieve.mockResolvedValue(mockBalance);
 
-    const result = await retrieveBalance(stripe, globals, {});
+    const result = await retrieveBalance(stripe, context, {});
 
     expect(stripe.balance.retrieve).toHaveBeenCalledWith(
       {},
       {
-        stripeAccount: globals.account,
+        stripeAccount: context.account,
       }
     );
     expect(result).toEqual(mockBalance);


### PR DESCRIPTION
To support cases like Connect where API requests are in the scope of a Connected Account, we're adding a new property to configuration -- Context.

```typescript
const stripeAgentToolkit = new StripeAgentToolkit({
  secretKey: process.env.STRIPE_SECRET_KEY!,
  configuration: {
    context: {
      account: 'acct_123',
    }
  }
})
```