### PR TITLE
Add X-Requested-With custom header to search

### DIFF
--- a/typescript/src/shared/functions.ts
+++ b/typescript/src/shared/functions.ts
@@ -247,6 +247,7 @@ export const searchDocumentation = async (
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        'X-Requested-With': 'fetch',
       },
       body: JSON.stringify(params),
     });

--- a/typescript/src/test/shared/functions.test.ts
+++ b/typescript/src/test/shared/functions.test.ts
@@ -605,6 +605,7 @@ describe('searchDocumentation', () => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        'X-Requested-With': 'fetch',
       },
       body: JSON.stringify(requestBody),
     });
@@ -636,6 +637,7 @@ describe('searchDocumentation', () => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        'X-Requested-With': 'fetch',
       },
       body: JSON.stringify(requestBody),
     });


### PR DESCRIPTION
We need to add the `X-Requested-With` header in requests to `/search` to ensure that requests are not blocked by CSRF protections in the future