### PR TITLE
Add Docker support

### DIFF
--- a/modelcontextprotocol/Dockerfile
+++ b/modelcontextprotocol/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:22.12-alpine AS builder
+
+# Must be entire project because `prepare` script is run during `npm install` and requires all files.
+COPY . /app
+
+WORKDIR /app
+
+RUN --mount=type=cache,target=/root/.npm npm install
+
+RUN --mount=type=cache,target=/root/.npm-production npm ci --ignore-scripts --omit-dev
+
+FROM node:22-alpine AS release
+
+COPY --from=builder /app/dist /app/dist
+COPY --from=builder /app/package.json /app/package.json
+COPY --from=builder /app/package-lock.json /app/package-lock.json
+
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+RUN npm ci --ignore-scripts --omit-dev
+
+ENTRYPOINT ["node", "/app/dist/index.js"]

--- a/modelcontextprotocol/README.md
+++ b/modelcontextprotocol/README.md
@@ -39,6 +39,27 @@ Add the following to your `claude_desktop_config.json`. See [here](https://model
 }
 ```
 
+of if you're using Docker
+
+```
+{
+    “mcpServers”: {
+        “stripe”: {
+            “command”: “docker",
+            “args”: [
+                “run”,
+                "--rm",
+                "-i",
+                “mcp/stripe”,
+                “--tools=all”,
+                “--api-key=STRIPE_SECRET_KEY”
+            ]
+        }
+    }
+}
+
+```
+
 ## Available tools
 
 | Tool                  | Description                     |
@@ -73,6 +94,21 @@ Run the following command in your terminal:
 ```bash
 # Start MCP Inspector and server with all tools
 npx @modelcontextprotocol/inspector node dist/index.js --tools=all --api-key=YOUR_STRIPE_SECRET_KEY
+```
+
+### Build using Docker
+
+First build the server
+
+```
+docker build -t mcp/stripe .
+```
+
+Run the following command in your terminal:
+
+```bash
+docker run -p 3000:3000 -p 5173:5173 -v /var/run/docker.sock:/var/run/docker.sock mcp/inspector docker run --rm -i mcp/stripe --tools=all --api-key=YOUR_STRIPE_SECRET_KEY
+
 ```
 
 ### Instructions


### PR DESCRIPTION
If there is interest in having Docker support for mcp/stripe, we can host releases of this server in the mcp dockerhub namespace https://hub.docker.com/u/mcp.

We also have experimental support for a single mcp endpoint that we think will simplify attaching new MCP servers like mcp/stripe to clients without having to make updates to configuration files such as claude_desktop_config.yaml. Let us know if you'd be interesting in collaborating on this (see [newsletter](https://www.linkedin.com/pulse/docker-labs-genai-19-docker-5v8oe/?trackingId=BnxOuH71TamzekTp%2BoKxEw%3D%3D) for more details).

One of this highlights of this approach is the ability to _inject_ secrets into a container at runtime.

![CleanShot 2025-03-03 at 20 02 22](https://github.com/user-attachments/assets/38cc2edc-3742-4ac8-bd5c-09490207cddf)

We'd love to work with your team on this.

