### PR TITLE
Fix invalid semicolons in mcpServers configuration JSON

### DIFF
--- a/modelcontextprotocol/README.md
+++ b/modelcontextprotocol/README.md
@@ -25,17 +25,17 @@ Add the following to your `claude_desktop_config.json`. See [here](https://model
 
 ```
 {
-    “mcpServers”: {
-        “stripe”: {
-            “command”: “npx”,
-            “args”: [
-                “-y”,
-                “@stripe/mcp”,
-                “--tools=all”,
-                “--api-key=STRIPE_SECRET_KEY”
-            ]
-        }
+  "mcpServers": {
+    "stripe": {
+      "command": "npx",
+      "args": [
+          "-y",
+          "@stripe/mcp",
+          "--tools=all",
+          "--api-key=STRIPE_SECRET_KEY"
+      ]
     }
+  }
 }
 ```
 


### PR DESCRIPTION
## Description
This PR fixes a error in our mcpServers configuration file where incorrect quotation marks (") were used instead of standard double quotes ("). This syntax error was causing the configuration to fail when parsed.

## Context:
When we copied and pasted the example json code on [the MCP document](https://github.com/stripe/agent-toolkit/blob/main/modelcontextprotocol/README.md#usage-with-claude-desktop), we encounted the following syntax error:

<img width="449" alt="スクリーンショット 2025-03-06 22 00 44" src="https://github.com/user-attachments/assets/9fec25e0-b996-4e10-a169-3cfeb9832a3f" />


## Changes
- Replaced all instances of incorrect quotation marks (") with standard double quotes (")

## Testing
Verified that the configuration now parses correctly and the server starts without errors.


<img width="489" alt="スクリーンショット 2025-03-06 22 02 28" src="https://github.com/user-attachments/assets/98b457a9-a408-4aba-8f24-ce91fb430490" />

