### PR TITLE
Add list_invoices and create_billing_portal_session tools

### DIFF
--- a/python/stripe_agent_toolkit/api.py
+++ b/python/stripe_agent_toolkit/api.py
@@ -17,6 +17,7 @@ from .functions import (
     create_price,
     list_prices,
     create_payment_link,
+    list_invoices,
     create_invoice,
     create_invoice_item,
     finalize_invoice,
@@ -60,6 +61,8 @@ class StripeAPI(BaseModel):
             return json.dumps(
                 create_payment_link(self._context, *args, **kwargs)
             )
+        elif method == "list_invoices":
+            return json.dumps(list_invoices(self._context, *args, **kwargs))
         elif method == "create_invoice":
             return json.dumps(create_invoice(self._context, *args, **kwargs))
         elif method == "create_invoice_item":

--- a/python/stripe_agent_toolkit/api.py
+++ b/python/stripe_agent_toolkit/api.py
@@ -24,6 +24,7 @@ from .functions import (
     retrieve_balance,
     create_refund,
     list_payment_intents,
+    create_billing_portal_session,
 )
 
 
@@ -78,6 +79,10 @@ class StripeAPI(BaseModel):
         elif method == "list_payment_intents":
             return json.dumps(
                 list_payment_intents(self._context, *args, **kwargs)
+            )
+        elif method == "create_billing_portal_session":
+            return json.dumps(
+                create_billing_portal_session(self._context, *args, **kwargs)
             )
         else:
             raise ValueError("Invalid method " + method)

--- a/python/stripe_agent_toolkit/configuration.py
+++ b/python/stripe_agent_toolkit/configuration.py
@@ -38,6 +38,7 @@ class Actions(TypedDict, total=False):
     balance: Optional[BalancePermission]
     refunds: Optional[Permission]
     payment_intents: Optional[Permission]
+    billing_portal_sessions: Optional[Permission]
 
 
 # Define Context type

--- a/python/stripe_agent_toolkit/functions.py
+++ b/python/stripe_agent_toolkit/functions.py
@@ -178,6 +178,34 @@ def create_payment_link(context: Context, price: str, quantity: int):
     return {"id": payment_link.id, "url": payment_link.url}
 
 
+def list_invoices(
+    context: Context,
+    customer: str,
+    limit: Optional[int] = None,
+):
+    """
+    List invoices.
+
+    Parameters:
+        customer (str): The ID of the customer.
+        limit (int, optional): The number of invoices to return.
+
+    Returns:
+        stripe.ListObject: A list of invoices.
+    """
+    invoice_data: dict = {
+        "customer": customer,
+    }
+    if limit:
+        invoice_data["limit"] = limit
+    if context.get("account") is not None:
+        account = context.get("account")
+        if account is not None:
+            invoice_data["stripe_account"] = account
+
+    return stripe.Invoice.list(**invoice_data).data
+
+
 def create_invoice(context: Context, customer: str, days_until_due: int = 30):
     """
     Create an invoice.

--- a/python/stripe_agent_toolkit/functions.py
+++ b/python/stripe_agent_toolkit/functions.py
@@ -358,3 +358,32 @@ def list_payment_intents(context: Context, customer: Optional[str] = None, limit
             payment_intent_data["stripe_account"] = account
 
     return stripe.PaymentIntent.list(**payment_intent_data).data
+
+def create_billing_portal_session(context: Context, customer: str, return_url: Optional[str] = None):
+    """
+    Creates a session of the customer portal.
+
+    Parameters:
+        customer (str): The ID of the customer to list payment intents for.
+        return_url (str, optional): The URL to return to after the session is complete.
+
+    Returns:
+        stripe.BillingPortalSession: The created billing portal session.
+    """
+    billing_portal_session_data: dict = {
+        "customer": customer,
+    }
+    if return_url:
+        billing_portal_session_data["return_url"] = return_url
+    if context.get("account") is not None:
+        account = context.get("account")
+        if account is not None:
+            billing_portal_session_data["stripe_account"] = account
+
+    session_object = stripe.billing_portal.Session.create(**billing_portal_session_data)
+
+    return {
+        "id": session_object.id,
+        "customer": session_object.customer,
+        "url": session_object.url,
+    }

--- a/python/stripe_agent_toolkit/functions.py
+++ b/python/stripe_agent_toolkit/functions.py
@@ -180,22 +180,22 @@ def create_payment_link(context: Context, price: str, quantity: int):
 
 def list_invoices(
     context: Context,
-    customer: str,
+    customer: Optional[str] = None,
     limit: Optional[int] = None,
 ):
     """
     List invoices.
 
     Parameters:
-        customer (str): The ID of the customer.
+        customer (str, optional): The ID of the customer.
         limit (int, optional): The number of invoices to return.
 
     Returns:
         stripe.ListObject: A list of invoices.
     """
-    invoice_data: dict = {
-        "customer": customer,
-    }
+    invoice_data: dict = {}
+    if customer:
+        invoice_data["customer"] = customer
     if limit:
         invoice_data["limit"] = limit
     if context.get("account") is not None:

--- a/python/stripe_agent_toolkit/prompts.py
+++ b/python/stripe_agent_toolkit/prompts.py
@@ -53,6 +53,14 @@ It takes two arguments:
 - quantity (int): The quantity of the product to include in the payment link.
 """
 
+LIST_INVOICES_PROMPT = """
+This tool will list invoices in Stripe.
+
+It takes two arguments:
+- customer (str): The ID of the customer to list the invoices for.
+- limit (int, optional): The number of prices to return.
+"""
+
 CREATE_INVOICE_PROMPT = """
 This tool will create an invoice in Stripe.
 

--- a/python/stripe_agent_toolkit/prompts.py
+++ b/python/stripe_agent_toolkit/prompts.py
@@ -103,3 +103,11 @@ It takes two arguments:
 - customer (str, optional): The ID of the customer to list payment intents for.
 - limit (int, optional): The number of payment intents to return.
 """
+
+CREATE_BILLING_PORTAL_SESSION_PROMPT = """
+This tool will create a billing portal session.
+
+It takes two arguments:
+- customer (str): The ID of the customer to create the invoice item for.
+- return_url (str, optional): The default URL to return to afterwards.
+"""

--- a/python/stripe_agent_toolkit/prompts.py
+++ b/python/stripe_agent_toolkit/prompts.py
@@ -57,7 +57,7 @@ LIST_INVOICES_PROMPT = """
 This tool will list invoices in Stripe.
 
 It takes two arguments:
-- customer (str): The ID of the customer to list the invoices for.
+- customer (str, optional): The ID of the customer to list the invoices for.
 - limit (int, optional): The number of prices to return.
 """
 

--- a/python/stripe_agent_toolkit/schema.py
+++ b/python/stripe_agent_toolkit/schema.py
@@ -109,8 +109,9 @@ class CreatePaymentLink(BaseModel):
 class ListInvoices(BaseModel):
     """Schema for the ``list_invoices`` operation."""
 
-    customer: str = Field(
-        ..., description="The ID of the customer to list invoices for."
+    customer: Optional[str] = Field(
+        None,
+        description="The ID of the customer to list invoices for.",
     )
     limit: Optional[int] = Field(
         None,

--- a/python/stripe_agent_toolkit/schema.py
+++ b/python/stripe_agent_toolkit/schema.py
@@ -192,3 +192,17 @@ class ListPaymentIntents(BaseModel):
             " Limit can range between 1 and 100."
         ),
     )
+
+class CreateBillingPortalSession(BaseModel):
+    """Schema for the ``create_billing_portal_session`` operation."""
+
+    customer: str = Field(
+        None,
+        description="The ID of the customer to create the billing portal session for.",
+    )
+    return_url: Optional[str] = Field(
+        None,
+        description=(
+            "The default URL to return to afterwards."
+        ),
+    )

--- a/python/stripe_agent_toolkit/schema.py
+++ b/python/stripe_agent_toolkit/schema.py
@@ -106,6 +106,21 @@ class CreatePaymentLink(BaseModel):
     )
 
 
+class ListInvoices(BaseModel):
+    """Schema for the ``list_invoices`` operation."""
+
+    customer: str = Field(
+        ..., description="The ID of the customer to list invoices for."
+    )
+    limit: Optional[int] = Field(
+        None,
+        description=(
+            "A limit on the number of objects to be returned."
+            " Limit can range between 1 and 100, and the default is 10."
+        ),
+    )
+
+
 class CreateInvoice(BaseModel):
     """Schema for the ``create_invoice`` operation."""
 

--- a/python/stripe_agent_toolkit/tools.py
+++ b/python/stripe_agent_toolkit/tools.py
@@ -15,6 +15,7 @@ from .prompts import (
     RETRIEVE_BALANCE_PROMPT,
     CREATE_REFUND_PROMPT,
     LIST_PAYMENT_INTENTS_PROMPT,
+    CREATE_BILLING_PORTAL_SESSION_PROMPT,
 )
 
 from .schema import (
@@ -32,6 +33,7 @@ from .schema import (
     RetrieveBalance,
     CreateRefund,
     ListPaymentIntents,
+    CreateBillingPortalSession,
 )
 
 tools: List[Dict] = [
@@ -186,6 +188,17 @@ tools: List[Dict] = [
         "actions": {
             "payment_intents": {
                 "read": True,
+            }
+        },
+    },
+    {
+        "method": "create_billing_portal_session",
+        "name": "Create Billing Portal Session",
+        "description": CREATE_BILLING_PORTAL_SESSION_PROMPT,
+        "args_schema": CreateBillingPortalSession,
+        "actions": {
+            "billing_portal_sessions": {
+                "create": True,
             }
         },
     },

--- a/python/stripe_agent_toolkit/tools.py
+++ b/python/stripe_agent_toolkit/tools.py
@@ -8,6 +8,7 @@ from .prompts import (
     CREATE_PRICE_PROMPT,
     LIST_PRICES_PROMPT,
     CREATE_PAYMENT_LINK_PROMPT,
+    LIST_INVOICES_PROMPT,
     CREATE_INVOICE_PROMPT,
     CREATE_INVOICE_ITEM_PROMPT,
     FINALIZE_INVOICE_PROMPT,
@@ -24,6 +25,7 @@ from .schema import (
     CreatePrice,
     ListPrices,
     CreatePaymentLink,
+    ListInvoices,
     CreateInvoice,
     CreateInvoiceItem,
     FinalizeInvoice,
@@ -107,6 +109,17 @@ tools: List[Dict] = [
         "actions": {
             "payment_links": {
                 "create": True,
+            }
+        },
+    },
+    {
+        "method": "list_invoices",
+        "name": "List Invoices",
+        "description": LIST_INVOICES_PROMPT,
+        "args_schema": ListInvoices,
+        "actions": {
+            "invoices": {
+                "read": True,
             }
         },
     },

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -16,6 +16,7 @@ from stripe_agent_toolkit.functions import (
     retrieve_balance,
     create_refund,
     list_payment_intents,
+    create_billing_portal_session,
 )
 
 
@@ -727,6 +728,86 @@ class TestStripeFunctions(unittest.TestCase):
             self.assertEqual(result, mock_payment_intents)
 
 
+    def test_create_billing_portal_session(self):
+        with mock.patch("stripe.billing_portal.Session.create") as mock_function:
+            mock_billing_portal_session = {
+                "id": "bps_123",
+                "url": "https://example.com",
+                "customer": "cus_123",
+                "configuration": "bpc_123",
+            }
+            mock_function.return_value = stripe.billing_portal.Session.construct_from(
+                mock_billing_portal_session, "sk_test_123"
+            )
+
+            result = create_billing_portal_session(context={}, customer="cus_123")
+
+            mock_function.assert_called_with(customer="cus_123")
+
+            self.assertEqual(result, {
+                "id": mock_billing_portal_session["id"],
+                "url": mock_billing_portal_session["url"],
+                "customer": mock_billing_portal_session["customer"],
+            })
+
+    def test_create_billing_portal_session_with_return_url(self):
+        with mock.patch("stripe.billing_portal.Session.create") as mock_function:
+            mock_billing_portal_session = {
+                "id": "bps_123",
+                "url": "https://example.com",
+                "customer": "cus_123",
+                "configuration": "bpc_123",
+            }
+            mock_function.return_value = stripe.billing_portal.Session.construct_from(
+                mock_billing_portal_session, "sk_test_123"
+            )
+
+            result = create_billing_portal_session(
+                context={},
+                customer="cus_123",
+                return_url="http://example.com"
+            )
+
+            mock_function.assert_called_with(
+                customer="cus_123",
+                return_url="http://example.com",
+            )
+
+            self.assertEqual(result, {
+                "id": mock_billing_portal_session["id"],
+                "url": mock_billing_portal_session["url"],
+                "customer": mock_billing_portal_session["customer"],
+            })
+
+    def test_create_billing_portal_session_with_context(self):
+        with mock.patch("stripe.billing_portal.Session.create") as mock_function:
+            mock_billing_portal_session = {
+                "id": "bps_123",
+                "url": "https://example.com",
+                "customer": "cus_123",
+                "configuration": "bpc_123",
+            }
+            mock_function.return_value = stripe.billing_portal.Session.construct_from(
+                mock_billing_portal_session, "sk_test_123"
+            )
+
+            result = create_billing_portal_session(
+                context={"account": "acct_123"},
+                customer="cus_123",
+                return_url="http://example.com"
+            )
+
+            mock_function.assert_called_with(
+                customer="cus_123",
+                return_url="http://example.com",
+                stripe_account="acct_123"
+            )
+
+            self.assertEqual(result, {
+                "id": mock_billing_portal_session["id"],
+                "url": mock_billing_portal_session["url"],
+                "customer": mock_billing_portal_session["customer"],
+            })
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -9,6 +9,7 @@ from stripe_agent_toolkit.functions import (
     create_price,
     list_prices,
     create_payment_link,
+    list_invoices,
     create_invoice,
     create_invoice_item,
     finalize_invoice,
@@ -358,6 +359,91 @@ class TestStripeFunctions(unittest.TestCase):
             )
 
             self.assertEqual(result, mock_payment_link)
+
+    def test_list_invoices(self):
+        with mock.patch("stripe.Invoice.list") as mock_function:
+            mock_invoice = {
+                "id": "in_123",
+                "hosted_invoice_url": "https://example.com",
+                "customer": "cus_123",
+                "status": "open",
+            }
+            mock_invoices = {
+                "object": "list",
+                "data": [
+                    stripe.Invoice.construct_from(
+                        mock_invoice,
+                        "sk_test_123",
+                    ),
+                ],
+                "has_more": False,
+                "url": "/v1/invoices",
+            }
+
+            mock_function.return_value = stripe.Invoice.construct_from(
+                mock_invoices, "sk_test_123"
+            )
+
+            result = list_invoices(context={}, customer="cus_123")
+
+            mock_function.assert_called_with(
+                customer="cus_123",
+            )
+
+            self.assertEqual(
+                result,
+                [
+                    {
+                        "id": mock_invoice["id"],
+                        "hosted_invoice_url": mock_invoice["hosted_invoice_url"],
+                        "customer": mock_invoice["customer"],
+                        "status": mock_invoice["status"],
+                    }
+                ],
+            )
+
+    def test_list_invoices_with_context(self):
+        with mock.patch("stripe.Invoice.list") as mock_function:
+            mock_invoice = {
+                "id": "in_123",
+                "hosted_invoice_url": "https://example.com",
+                "customer": "cus_123",
+                "status": "open",
+            }
+            mock_invoices = {
+                "object": "list",
+                "data": [
+                    stripe.Invoice.construct_from(
+                        mock_invoice,
+                        "sk_test_123",
+                    ),
+                ],
+                "has_more": False,
+                "url": "/v1/invoices",
+            }
+
+            mock_function.return_value = stripe.Invoice.construct_from(
+                mock_invoices, "sk_test_123"
+            )
+
+            result = list_invoices(context={"account": "acct_123"}, customer="cus_123")
+
+            mock_function.assert_called_with(
+                customer="cus_123",
+                stripe_account="acct_123",
+            )
+
+            self.assertEqual(
+                result,
+                [
+                    {
+                        "id": mock_invoice["id"],
+                        "hosted_invoice_url": mock_invoice["hosted_invoice_url"],
+                        "customer": mock_invoice["customer"],
+                        "status": mock_invoice["status"],
+                    }
+                ],
+            )
 
     def test_create_invoice(self):
         with mock.patch("stripe.Invoice.create") as mock_function:

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -385,10 +385,93 @@ class TestStripeFunctions(unittest.TestCase):
                 mock_invoices, "sk_test_123"
             )
 
+            result = list_invoices(context={})
+
+            mock_function.assert_called_with()
+
+            self.assertEqual(
+                result,
+                [
+                    {
+                        "id": mock_invoice["id"],
+                        "hosted_invoice_url": mock_invoice["hosted_invoice_url"],
+                        "customer": mock_invoice["customer"],
+                        "status": mock_invoice["status"],
+                    }
+                ],
+            )
+
+    def test_list_invoices_with_customer(self):
+        with mock.patch("stripe.Invoice.list") as mock_function:
+            mock_invoice = {
+                "id": "in_123",
+                "hosted_invoice_url": "https://example.com",
+                "customer": "cus_123",
+                "status": "open",
+            }
+            mock_invoices = {
+                "object": "list",
+                "data": [
+                    stripe.Invoice.construct_from(
+                        mock_invoice,
+                        "sk_test_123",
+                    ),
+                ],
+                "has_more": False,
+                "url": "/v1/invoices",
+            }
+
+            mock_function.return_value = stripe.Invoice.construct_from(
+                mock_invoices, "sk_test_123"
+            )
+
             result = list_invoices(context={}, customer="cus_123")
 
             mock_function.assert_called_with(
                 customer="cus_123",
+            )
+
+            self.assertEqual(
+                result,
+                [
+                    {
+                        "id": mock_invoice["id"],
+                        "hosted_invoice_url": mock_invoice["hosted_invoice_url"],
+                        "customer": mock_invoice["customer"],
+                        "status": mock_invoice["status"],
+                    }
+                ],
+            )
+
+    def test_list_invoices_with_customer_and_limit(self):
+        with mock.patch("stripe.Invoice.list") as mock_function:
+            mock_invoice = {
+                "id": "in_123",
+                "hosted_invoice_url": "https://example.com",
+                "customer": "cus_123",
+                "status": "open",
+            }
+            mock_invoices = {
+                "object": "list",
+                "data": [
+                    stripe.Invoice.construct_from(
+                        mock_invoice,
+                        "sk_test_123",
+                    ),
+                ],
+                "has_more": False,
+                "url": "/v1/invoices",
+            }
+
+            mock_function.return_value = stripe.Invoice.construct_from(
+                mock_invoices, "sk_test_123"
+            )
+
+            result = list_invoices(context={}, customer="cus_123", limit=100)
+
+            mock_function.assert_called_with(
+                customer="cus_123",
+                limit=100,
             )
 
             self.assertEqual(


### PR DESCRIPTION
This PR adds two new tools to the Python SDK:
1. `list_invoices`
2. `create_billing_portal_session`

Usage:

```py
stripe_agent_toolkit = StripeAgentToolkit(
    secret_key=os.getenv("STRIPE_SECRET_KEY"),
    configuration={
        "actions": {
            "invoices": {
                "read": True,
            },
            "billing_portal_sessions": {
                "create": True,
            },
        }
    },
)
```

