### PR TITLE
add customer to context

### DIFF
--- a/typescript/src/ai-sdk/toolkit.ts
+++ b/typescript/src/ai-sdk/toolkit.ts
@@ -34,7 +34,8 @@ class StripeAgentToolkit {
     this._stripe = new StripeAPI(secretKey, configuration.context);
     this.tools = {};
 
-    const filteredTools = tools.filter((tool) =>
+    const context = configuration.context || {};
+    const filteredTools = tools(context).filter((tool) =>
       isToolAllowed(tool, configuration)
     );
 

--- a/typescript/src/langchain/toolkit.ts
+++ b/typescript/src/langchain/toolkit.ts
@@ -18,7 +18,8 @@ class StripeAgentToolkit implements BaseToolkit {
   }) {
     this._stripe = new StripeAPI(secretKey, configuration.context);
 
-    const filteredTools = tools.filter((tool) =>
+    const context = configuration.context || {};
+    const filteredTools = tools(context).filter((tool) =>
       isToolAllowed(tool, configuration)
     );
 

--- a/typescript/src/modelcontextprotocol/toolkit.ts
+++ b/typescript/src/modelcontextprotocol/toolkit.ts
@@ -21,7 +21,8 @@ class StripeAgentToolkit extends McpServer {
 
     this._stripe = new StripeAPI(secretKey, configuration.context);
 
-    const filteredTools = tools.filter((tool) =>
+    const context = configuration.context || {};
+    const filteredTools = tools(context).filter((tool) =>
       isToolAllowed(tool, configuration)
     );
 

--- a/typescript/src/openai/toolkit.ts
+++ b/typescript/src/openai/toolkit.ts
@@ -22,7 +22,8 @@ class StripeAgentToolkit {
   }) {
     this._stripe = new StripeAPI(secretKey, configuration.context);
 
-    const filteredTools = tools.filter((tool) =>
+    const context = configuration.context || {};
+    const filteredTools = tools(context).filter((tool) =>
       isToolAllowed(tool, configuration)
     );
 

--- a/typescript/src/shared/configuration.ts
+++ b/typescript/src/shared/configuration.ts
@@ -32,6 +32,10 @@ export type Context = {
   // Account is a Stripe Connected Account ID. If set, the integration will
   // make requests for this Account.
   account?: string;
+
+  // Customer is a Stripe Customer ID. If set, the integration will
+  // make requests for this Customer.
+  customer?: string;
 };
 
 // Configuration provides various settings and options for the integration

--- a/typescript/src/shared/functions.ts
+++ b/typescript/src/shared/functions.ts
@@ -22,7 +22,7 @@ import type {Context} from './configuration';
 export const createCustomer = async (
   stripe: Stripe,
   context: Context,
-  params: z.infer<typeof createCustomerParameters>
+  params: z.infer<ReturnType<typeof createCustomerParameters>>
 ) => {
   try {
     const customer = await stripe.customers.create(
@@ -39,7 +39,7 @@ export const createCustomer = async (
 export const listCustomers = async (
   stripe: Stripe,
   context: Context,
-  params: z.infer<typeof listCustomersParameters>
+  params: z.infer<ReturnType<typeof listCustomersParameters>>
 ) => {
   try {
     const customers = await stripe.customers.list(
@@ -56,7 +56,7 @@ export const listCustomers = async (
 export const createProduct = async (
   stripe: Stripe,
   context: Context,
-  params: z.infer<typeof createProductParameters>
+  params: z.infer<ReturnType<typeof createProductParameters>>
 ) => {
   try {
     const product = await stripe.products.create(
@@ -73,7 +73,7 @@ export const createProduct = async (
 export const listProducts = async (
   stripe: Stripe,
   context: Context,
-  params: z.infer<typeof listProductsParameters>
+  params: z.infer<ReturnType<typeof listProductsParameters>>
 ) => {
   try {
     const products = await stripe.products.list(
@@ -90,7 +90,7 @@ export const listProducts = async (
 export const createPrice = async (
   stripe: Stripe,
   context: Context,
-  params: z.infer<typeof createPriceParameters>
+  params: z.infer<ReturnType<typeof createPriceParameters>>
 ) => {
   try {
     const price = await stripe.prices.create(
@@ -107,7 +107,7 @@ export const createPrice = async (
 export const listPrices = async (
   stripe: Stripe,
   context: Context,
-  params: z.infer<typeof listPricesParameters>
+  params: z.infer<ReturnType<typeof listPricesParameters>>
 ) => {
   try {
     const prices = await stripe.prices.list(
@@ -124,7 +124,7 @@ export const listPrices = async (
 export const createPaymentLink = async (
   stripe: Stripe,
   context: Context,
-  params: z.infer<typeof createPaymentLinkParameters>
+  params: z.infer<ReturnType<typeof createPaymentLinkParameters>>
 ) => {
   try {
     const paymentLink = await stripe.paymentLinks.create(
@@ -143,9 +143,13 @@ export const createPaymentLink = async (
 export const createInvoice = async (
   stripe: Stripe,
   context: Context,
-  params: z.infer<typeof createInvoiceParameters>
+  params: z.infer<ReturnType<typeof createInvoiceParameters>>
 ) => {
   try {
+    if (context.customer) {
+      params.customer = context.customer;
+    }
+
     const invoice = await stripe.invoices.create(
       params,
       context.account ? {stripeAccount: context.account} : undefined
@@ -165,9 +169,13 @@ export const createInvoice = async (
 export const listInvoices = async (
   stripe: Stripe,
   context: Context,
-  params: z.infer<typeof listInvoicesParameters>
+  params: z.infer<ReturnType<typeof listInvoicesParameters>>
 ) => {
   try {
+    if (context.customer) {
+      params.customer = context.customer;
+    }
+
     const invoices = await stripe.invoices.list(
       params,
       context.account ? {stripeAccount: context.account} : undefined
@@ -182,10 +190,15 @@ export const listInvoices = async (
 export const createInvoiceItem = async (
   stripe: Stripe,
   context: Context,
-  params: z.infer<typeof createInvoiceItemParameters>
+  params: z.infer<ReturnType<typeof createInvoiceItemParameters>>
 ) => {
   try {
+    if (context.customer) {
+      params.customer = context.customer;
+    }
+
     const invoiceItem = await stripe.invoiceItems.create(
+      // @ts-ignore
       params,
       context.account ? {stripeAccount: context.account} : undefined
     );
@@ -202,7 +215,7 @@ export const createInvoiceItem = async (
 export const finalizeInvoice = async (
   stripe: Stripe,
   context: Context,
-  params: z.infer<typeof finalizeInvoiceParameters>
+  params: z.infer<ReturnType<typeof finalizeInvoiceParameters>>
 ) => {
   try {
     const invoice = await stripe.invoices.finalizeInvoice(
@@ -224,7 +237,7 @@ export const finalizeInvoice = async (
 export const retrieveBalance = async (
   stripe: Stripe,
   context: Context,
-  params: z.infer<typeof retrieveBalanceParameters>
+  params: z.infer<ReturnType<typeof retrieveBalanceParameters>>
 ) => {
   try {
     const balance = await stripe.balance.retrieve(
@@ -241,7 +254,7 @@ export const retrieveBalance = async (
 export const createRefund = async (
   stripe: Stripe,
   context: Context,
-  params: z.infer<typeof createRefundParameters>
+  params: z.infer<ReturnType<typeof createRefundParameters>>
 ) => {
   try {
     const refund = await stripe.refunds.create(
@@ -258,9 +271,13 @@ export const createRefund = async (
 export const listPaymentIntents = async (
   stripe: Stripe,
   context: Context,
-  params: z.infer<typeof listPaymentIntentsParameters>
+  params: z.infer<ReturnType<typeof listPaymentIntentsParameters>>
 ) => {
   try {
+    if (context.customer) {
+      params.customer = context.customer;
+    }
+
     const paymentIntents = await stripe.paymentIntents.list(
       params,
       context.account ? {stripeAccount: context.account} : undefined
@@ -282,7 +299,7 @@ export const listPaymentIntents = async (
 export const searchDocumentation = async (
   stripe: Stripe,
   context: Context,
-  params: z.infer<typeof searchDocumentationParameters>
+  params: z.infer<ReturnType<typeof searchDocumentationParameters>>
 ) => {
   try {
     const endpoint = 'https://ai.stripe.com/search';

--- a/typescript/src/shared/parameters.ts
+++ b/typescript/src/shared/parameters.ts
@@ -1,161 +1,226 @@
 import {z} from 'zod';
+import type {Context} from './configuration';
 
-export const createCustomerParameters = z.object({
-  name: z.string().describe('The name of the customer'),
-  email: z.string().email().optional().describe('The email of the customer'),
-});
+export const createCustomerParameters = (
+  _context: Context = {}
+): z.AnyZodObject =>
+  z.object({
+    name: z.string().describe('The name of the customer'),
+    email: z.string().email().optional().describe('The email of the customer'),
+  });
 
-export const listCustomersParameters = z.object({
-  limit: z
-    .number()
-    .int()
-    .min(1)
-    .max(100)
-    .optional()
-    .describe(
-      'A limit on the number of objects to be returned. Limit can range between 1 and 100.'
-    ),
-  email: z
-    .string()
-    .optional()
-    .describe(
-      "A case-sensitive filter on the list based on the customer's email field. The value must be a string."
-    ),
-});
+export const listCustomersParameters = (_context: Context = {}) =>
+  z.object({
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        'A limit on the number of objects to be returned. Limit can range between 1 and 100.'
+      ),
+    email: z
+      .string()
+      .optional()
+      .describe(
+        "A case-sensitive filter on the list based on the customer's email field. The value must be a string."
+      ),
+  });
 
-export const createProductParameters = z.object({
-  name: z.string().describe('The name of the product.'),
-  description: z
-    .string()
-    .optional()
-    .describe('The description of the product.'),
-});
+export const createProductParameters = (_context: Context = {}) =>
+  z.object({
+    name: z.string().describe('The name of the product.'),
+    description: z
+      .string()
+      .optional()
+      .describe('The description of the product.'),
+  });
 
-export const listProductsParameters = z.object({
-  limit: z
-    .number()
-    .int()
-    .min(1)
-    .max(100)
-    .optional()
-    .describe(
-      'A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.'
-    ),
-});
+export const listProductsParameters = (
+  _context: Context = {}
+): z.AnyZodObject =>
+  z.object({
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        'A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.'
+      ),
+  });
 
-export const createPriceParameters = z.object({
-  product: z
-    .string()
-    .describe('The ID of the product to create the price for.'),
-  unit_amount: z
-    .number()
-    .int()
-    .describe('The unit amount of the price in cents.'),
-  currency: z.string().describe('The currency of the price.'),
-});
+export const createPriceParameters = (_context: Context = {}) =>
+  z.object({
+    product: z
+      .string()
+      .describe('The ID of the product to create the price for.'),
+    unit_amount: z
+      .number()
+      .int()
+      .describe('The unit amount of the price in cents.'),
+    currency: z.string().describe('The currency of the price.'),
+  });
 
-export const listPricesParameters = z.object({
-  product: z
-    .string()
-    .optional()
-    .describe('The ID of the product to list prices for.'),
-  limit: z
-    .number()
-    .int()
-    .min(1)
-    .max(100)
-    .optional()
-    .describe(
-      'A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.'
-    ),
-});
+export const listPricesParameters = (_context: Context = {}): z.AnyZodObject =>
+  z.object({
+    product: z
+      .string()
+      .optional()
+      .describe('The ID of the product to list prices for.'),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        'A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.'
+      ),
+  });
 
-export const createPaymentLinkParameters = z.object({
-  price: z
-    .string()
-    .describe('The ID of the price to create the payment link for.'),
-  quantity: z
-    .number()
-    .int()
-    .describe('The quantity of the product to include.'),
-});
+export const createPaymentLinkParameters = (_context: Context = {}) =>
+  z.object({
+    price: z
+      .string()
+      .describe('The ID of the price to create the payment link for.'),
+    quantity: z
+      .number()
+      .int()
+      .describe('The quantity of the product to include.'),
+  });
 
-export const createInvoiceParameters = z.object({
-  customer: z
-    .string()
-    .describe('The ID of the customer to create the invoice for.'),
-  days_until_due: z
-    .number()
-    .int()
-    .optional()
-    .describe('The number of days until the invoice is due.'),
-});
+export const createInvoiceParameters = (
+  context: Context = {}
+): z.AnyZodObject => {
+  const schema = z.object({
+    customer: z
+      .string()
+      .describe('The ID of the customer to create the invoice for.'),
+    days_until_due: z
+      .number()
+      .int()
+      .optional()
+      .describe('The number of days until the invoice is due.'),
+  });
 
-export const listInvoicesParameters = z.object({
-  customer: z
-    .string()
-    .optional()
-    .describe('The ID of the customer to list invoices for.'),
-  limit: z
-    .number()
-    .int()
-    .min(1)
-    .max(100)
-    .optional()
-    .describe(
-      'A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.'
-    ),
-});
+  if (context.customer) {
+    return schema.omit({customer: true});
+  } else {
+    return schema;
+  }
+};
 
-export const createInvoiceItemParameters = z.object({
-  customer: z
-    .string()
-    .describe('The ID of the customer to create the invoice item for.'),
-  price: z.string().describe('The ID of the price for the item.'),
-  invoice: z.string().describe('The ID of the invoice to create the item for.'),
-});
+export const listInvoicesParameters = (
+  context: Context = {}
+): z.AnyZodObject => {
+  const schema = z.object({
+    customer: z
+      .string()
+      .optional()
+      .describe('The ID of the customer to list invoices for.'),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        'A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.'
+      ),
+  });
 
-export const finalizeInvoiceParameters = z.object({
-  invoice: z.string().describe('The ID of the invoice to finalize.'),
-});
+  if (context.customer) {
+    return schema.omit({customer: true});
+  } else {
+    return schema;
+  }
+};
+export const createInvoiceItemParameters = (
+  context: Context = {}
+): z.AnyZodObject => {
+  const schema = z.object({
+    customer: z
+      .string()
+      .describe('The ID of the customer to create the invoice item for.'),
+    price: z.string().describe('The ID of the price for the item.'),
+    invoice: z
+      .string()
+      .describe('The ID of the invoice to create the item for.'),
+  });
 
-export const retrieveBalanceParameters = z.object({});
+  if (context.customer) {
+    return schema.omit({customer: true});
+  } else {
+    return schema;
+  }
+};
 
-export const createRefundParameters = z.object({
-  payment_intent: z.string().describe('The ID of the PaymentIntent to refund.'),
-  amount: z
-    .number()
-    .int()
-    .optional()
-    .describe('The amount to refund in cents.'),
-});
+export const finalizeInvoiceParameters = (
+  _context: Context = {}
+): z.AnyZodObject =>
+  z.object({
+    invoice: z.string().describe('The ID of the invoice to finalize.'),
+  });
 
-export const listPaymentIntentsParameters = z.object({
-  customer: z
-    .string()
-    .optional()
-    .describe('The ID of the customer to list payment intents for.'),
-  limit: z
-    .number()
-    .int()
-    .min(1)
-    .max(100)
-    .optional()
-    .describe(
-      'A limit on the number of objects to be returned. Limit can range between 1 and 100.'
-    ),
-});
+export const retrieveBalanceParameters = (
+  _context: Context = {}
+): z.AnyZodObject => z.object({});
 
-export const searchDocumentationParameters = z.object({
-  question: z
-    .string()
-    .describe(
-      'The user question about integrating with Stripe will be used to search the documentation.'
-    ),
-  language: z
-    .enum(['dotnet', 'go', 'java', 'node', 'php', 'ruby', 'python', 'curl'])
-    .optional()
-    .describe(
-      'The programming language to search for in the the documentation.'
-    ),
-});
+export const createRefundParameters = (
+  _context: Context = {}
+): z.AnyZodObject =>
+  z.object({
+    payment_intent: z
+      .string()
+      .describe('The ID of the PaymentIntent to refund.'),
+    amount: z
+      .number()
+      .int()
+      .optional()
+      .describe('The amount to refund in cents.'),
+  });
+
+export const listPaymentIntentsParameters = (
+  context: Context = {}
+): z.AnyZodObject => {
+  const schema = z.object({
+    customer: z
+      .string()
+      .optional()
+      .describe('The ID of the customer to list payment intents for.'),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        'A limit on the number of objects to be returned. Limit can range between 1 and 100.'
+      ),
+  });
+
+  if (context.customer) {
+    return schema.omit({customer: true});
+  } else {
+    return schema;
+  }
+};
+export const searchDocumentationParameters = (
+  _context: Context = {}
+): z.AnyZodObject =>
+  z.object({
+    question: z
+      .string()
+      .describe(
+        'The user question about integrating with Stripe will be used to search the documentation.'
+      ),
+    language: z
+      .enum(['dotnet', 'go', 'java', 'node', 'php', 'ruby', 'python', 'curl'])
+      .optional()
+      .describe(
+        'The programming language to search for in the the documentation.'
+      ),
+  });

--- a/typescript/src/shared/prompts.ts
+++ b/typescript/src/shared/prompts.ts
@@ -1,4 +1,6 @@
-export const createCustomerPrompt = `
+import type {Context} from './configuration';
+
+export const createCustomerPrompt = (_context: Context = {}) => `
 This tool will create a customer in Stripe.
 
 It takes two arguments:
@@ -6,13 +8,13 @@ It takes two arguments:
 - email (str, optional): The email of the customer.
 `;
 
-export const listCustomersPrompt = `
+export const listCustomersPrompt = (_context: Context = {}) => `
 This tool will fetch a list of Customers from Stripe.
 
 It takes no input.
 `;
 
-export const createProductPrompt = `
+export const createProductPrompt = (_context: Context = {}) => `
 This tool will create a product in Stripe.
 
 It takes two arguments:
@@ -20,14 +22,14 @@ It takes two arguments:
 - description (str, optional): The description of the product.
 `;
 
-export const listProductsPrompt = `
+export const listProductsPrompt = (_context: Context = {}) => `
 This tool will fetch a list of Products from Stripe.
 
 It takes one optional argument:
 - limit (int, optional): The number of products to return.
 `;
 
-export const createPricePrompt = `
+export const createPricePrompt = (_context: Context = {}) => `
 This tool will create a price in Stripe. If a product has not already been specified, a product should be created first.
 
 It takes three arguments:
@@ -36,7 +38,7 @@ It takes three arguments:
 - currency (str): The currency of the price.
 `;
 
-export const listPricesPrompt = `
+export const listPricesPrompt = (_context: Context = {}) => `
 This tool will fetch a list of Prices from Stripe.
 
 It takes two arguments.
@@ -44,7 +46,7 @@ It takes two arguments.
 - limit (int, optional): The number of prices to return.
 `;
 
-export const createPaymentLinkPrompt = `
+export const createPaymentLinkPrompt = (_context: Context = {}) => `
 This tool will create a payment link in Stripe.
 
 It takes two arguments:
@@ -52,41 +54,60 @@ It takes two arguments:
 - quantity (int): The quantity of the product to include in the payment link.
 `;
 
-export const createInvoicePrompt = `
+export const createInvoicePrompt = (context: Context = {}) => {
+  const customerArg = context.customer
+    ? ''
+    : `- customer (str): The ID of the customer to create the invoice for.\n`;
+
+  return `
 This tool will create an invoice in Stripe.
 
-It takes one argument:
-- customer (str): The ID of the customer to create the invoice for.
+It takes ${context.customer ? 'one' : 'two'} argument${context.customer ? '' : 's'}:
+${customerArg}
+- days_until_due (int, optional): The number of days until the invoice is due.
 `;
+};
 
-export const listInvoicesPrompt = `
+export const listInvoicesPrompt = (context: Context = {}) => {
+  const customerArg = context.customer
+    ? ''
+    : `- customer (str, optional): The ID of the customer to list invoices for.\n`;
+
+  return `
 This tool will fetch a list of Invoices from Stripe.
 
-It takes two arguments:
-- customer (str, optional): The ID of the customer to list invoices for.
+It takes ${context.customer ? 'one' : 'two'} argument${context.customer ? '' : 's'}:
+${customerArg}
 - limit (int, optional): The number of invoices to return.
 `;
+};
 
-export const createInvoiceItemPrompt = `
+export const createInvoiceItemPrompt = (context: Context = {}) => {
+  const customerArg = context.customer
+    ? ''
+    : `- customer (str): The ID of the customer to create the invoice item for.\n`;
+
+  return `
 This tool will create an invoice item in Stripe.
 
-It takes two arguments:
-- customer (str): The ID of the customer to create the invoice item for.
+It takes ${context.customer ? 'one' : 'two'} argument${context.customer ? '' : 's'}:
+${customerArg}
 - price (str): The ID of the price to create the invoice item for.
 `;
+};
 
-export const finalizeInvoicePrompt = `
+export const finalizeInvoicePrompt = (_context: Context = {}) => `
 This tool will finalize an invoice in Stripe.
 
 It takes one argument:
 - invoice (str): The ID of the invoice to finalize.
 `;
 
-export const retrieveBalancePrompt = `
+export const retrieveBalancePrompt = (_context: Context = {}) => `
 This tool will retrieve the balance from Stripe. It takes no input.
 `;
 
-export const createRefundPrompt = `
+export const createRefundPrompt = (_context: Context = {}) => `
 This tool will refund a payment intent in Stripe.
 
 It takes three arguments:
@@ -95,15 +116,21 @@ It takes three arguments:
 - reason (str, optional): The reason for the refund.
 `;
 
-export const listPaymentIntentsPrompt = `
+export const listPaymentIntentsPrompt = (context: Context = {}) => {
+  const customerArg = context.customer
+    ? ''
+    : `- customer (str, optional): The ID of the customer to list payment intents for.\n`;
+
+  return `
 This tool will list payment intents in Stripe.
 
-It takes two arguments:
-- customer (str, optional): The ID of the customer to list payment intents for.
+It takes ${context.customer ? 'one' : 'two'} argument${context.customer ? '' : 's'}:
+${customerArg}
 - limit (int, optional): The number of payment intents to return.
 `;
+};
 
-export const searchDocumentationPrompt = `
+export const searchDocumentationPrompt = (_context: Context = {}) => `
 This tool will take in a user question about integrating with Stripe in their application, then search and retrieve relevant Stripe documentation to answer the question.
 
 It takes two arguments:

--- a/typescript/src/shared/tools.ts
+++ b/typescript/src/shared/tools.ts
@@ -36,6 +36,8 @@ import {
   listPaymentIntentsParameters,
 } from './parameters';
 
+import type {Context} from './configuration';
+
 export type Tool = {
   method: string;
   name: string;
@@ -48,12 +50,12 @@ export type Tool = {
   };
 };
 
-const tools: Tool[] = [
+const tools = (context: Context): Tool[] => [
   {
     method: 'create_customer',
     name: 'Create Customer',
-    description: createCustomerPrompt,
-    parameters: createCustomerParameters,
+    description: createCustomerPrompt(context),
+    parameters: createCustomerParameters(context),
     actions: {
       customers: {
         create: true,
@@ -63,8 +65,8 @@ const tools: Tool[] = [
   {
     method: 'list_customers',
     name: 'List Customers',
-    description: listCustomersPrompt,
-    parameters: listCustomersParameters,
+    description: listCustomersPrompt(context),
+    parameters: listCustomersParameters(context),
     actions: {
       customers: {
         read: true,
@@ -74,8 +76,8 @@ const tools: Tool[] = [
   {
     method: 'create_product',
     name: 'Create Product',
-    description: createProductPrompt,
-    parameters: createProductParameters,
+    description: createProductPrompt(context),
+    parameters: createProductParameters(context),
     actions: {
       products: {
         create: true,
@@ -85,8 +87,8 @@ const tools: Tool[] = [
   {
     method: 'list_products',
     name: 'List Products',
-    description: listProductsPrompt,
-    parameters: listProductsParameters,
+    description: listProductsPrompt(context),
+    parameters: listProductsParameters(context),
     actions: {
       products: {
         read: true,
@@ -96,8 +98,8 @@ const tools: Tool[] = [
   {
     method: 'create_price',
     name: 'Create Price',
-    description: createPricePrompt,
-    parameters: createPriceParameters,
+    description: createPricePrompt(context),
+    parameters: createPriceParameters(context),
     actions: {
       prices: {
         create: true,
@@ -107,8 +109,8 @@ const tools: Tool[] = [
   {
     method: 'list_prices',
     name: 'List Prices',
-    description: listPricesPrompt,
-    parameters: listPricesParameters,
+    description: listPricesPrompt(context),
+    parameters: listPricesParameters(context),
     actions: {
       prices: {
         read: true,
@@ -118,8 +120,8 @@ const tools: Tool[] = [
   {
     method: 'create_payment_link',
     name: 'Create Payment Link',
-    description: createPaymentLinkPrompt,
-    parameters: createPaymentLinkParameters,
+    description: createPaymentLinkPrompt(context),
+    parameters: createPaymentLinkParameters(context),
     actions: {
       paymentLinks: {
         create: true,
@@ -129,8 +131,8 @@ const tools: Tool[] = [
   {
     method: 'create_invoice',
     name: 'Create Invoice',
-    description: createInvoicePrompt,
-    parameters: createInvoiceParameters,
+    description: createInvoicePrompt(context),
+    parameters: createInvoiceParameters(context),
     actions: {
       invoices: {
         create: true,
@@ -140,8 +142,8 @@ const tools: Tool[] = [
   {
     method: 'list_invoices',
     name: 'List Invoices',
-    description: listInvoicesPrompt,
-    parameters: listInvoicesParameters,
+    description: listInvoicesPrompt(context),
+    parameters: listInvoicesParameters(context),
     actions: {
       invoices: {
         read: true,
@@ -151,8 +153,8 @@ const tools: Tool[] = [
   {
     method: 'create_invoice_item',
     name: 'Create Invoice Item',
-    description: createInvoiceItemPrompt,
-    parameters: createInvoiceItemParameters,
+    description: createInvoiceItemPrompt(context),
+    parameters: createInvoiceItemParameters(context),
     actions: {
       invoiceItems: {
         create: true,
@@ -162,8 +164,8 @@ const tools: Tool[] = [
   {
     method: 'finalize_invoice',
     name: 'Finalize Invoice',
-    description: finalizeInvoicePrompt,
-    parameters: finalizeInvoiceParameters,
+    description: finalizeInvoicePrompt(context),
+    parameters: finalizeInvoiceParameters(context),
     actions: {
       invoices: {
         update: true,
@@ -173,8 +175,8 @@ const tools: Tool[] = [
   {
     method: 'retrieve_balance',
     name: 'Retrieve Balance',
-    description: retrieveBalancePrompt,
-    parameters: retrieveBalanceParameters,
+    description: retrieveBalancePrompt(context),
+    parameters: retrieveBalanceParameters(context),
     actions: {
       balance: {
         read: true,
@@ -184,8 +186,8 @@ const tools: Tool[] = [
   {
     method: 'create_refund',
     name: 'Create Refund',
-    description: createRefundPrompt,
-    parameters: createRefundParameters,
+    description: createRefundPrompt(context),
+    parameters: createRefundParameters(context),
     actions: {
       refunds: {
         create: true,
@@ -195,8 +197,8 @@ const tools: Tool[] = [
   {
     method: 'list_payment_intents',
     name: 'List Payment Intents',
-    description: listPaymentIntentsPrompt,
-    parameters: listPaymentIntentsParameters,
+    description: listPaymentIntentsPrompt(context),
+    parameters: listPaymentIntentsParameters(context),
     actions: {
       paymentIntents: {
         read: true,
@@ -206,8 +208,8 @@ const tools: Tool[] = [
   {
     method: 'search_documentation',
     name: 'Search Documentation',
-    description: searchDocumentationPrompt,
-    parameters: searchDocumentationParameters,
+    description: searchDocumentationPrompt(context),
+    parameters: searchDocumentationParameters(context),
     actions: {
       documentation: {
         read: true,

--- a/typescript/src/test/shared/parameters.test.ts
+++ b/typescript/src/test/shared/parameters.test.ts
@@ -1,0 +1,287 @@
+import {
+  createCustomerParameters,
+  createInvoiceItemParameters,
+  createInvoiceParameters,
+  createPaymentLinkParameters,
+  createPriceParameters,
+  createProductParameters,
+  createRefundParameters,
+  finalizeInvoiceParameters,
+  listCustomersParameters,
+  listInvoicesParameters,
+  listPaymentIntentsParameters,
+  listPricesParameters,
+  listProductsParameters,
+  retrieveBalanceParameters,
+  searchDocumentationParameters,
+} from '../../shared/parameters';
+
+describe('createCustomerParameters', () => {
+  it('should return the correct parameters if no context', () => {
+    // Create the parameters schema with an empty context
+    const parameters = createCustomerParameters({});
+
+    // Validate that the schema has the expected keys
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['name', 'email']);
+    expect(fields.length).toBe(2);
+  });
+
+  it('should return the correct parameters if customer is specified', () => {
+    const parameters = createCustomerParameters({customer: 'cus_123'});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['name', 'email']);
+    expect(fields.length).toBe(2);
+  });
+});
+
+describe('listCustomersParameters', () => {
+  it('should return the correct parameters if no context', () => {
+    const parameters = listCustomersParameters({});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['limit', 'email']);
+    expect(fields.length).toBe(2);
+  });
+
+  it('should return the correct parameters if customer is specified', () => {
+    const parameters = listCustomersParameters({customer: 'cus_123'});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['limit', 'email']);
+    expect(fields.length).toBe(2);
+  });
+});
+
+describe('createProductParameters', () => {
+  it('should return the correct parameters if no context', () => {
+    const parameters = createProductParameters({});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['name', 'description']);
+    expect(fields.length).toBe(2);
+  });
+
+  it('should return the correct parameters if customer is specified', () => {
+    const parameters = createProductParameters({customer: 'cus_123'});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['name', 'description']);
+    expect(fields.length).toBe(2);
+  });
+});
+
+describe('listProductsParameters', () => {
+  it('should return the correct parameters if no context', () => {
+    const parameters = listProductsParameters({});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['limit']);
+    expect(fields.length).toBe(1);
+  });
+
+  it('should return the correct parameters if customer is specified', () => {
+    const parameters = listProductsParameters({customer: 'cus_123'});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['limit']);
+    expect(fields.length).toBe(1);
+  });
+});
+
+describe('createPriceParameters', () => {
+  it('should return the correct parameters if no context', () => {
+    const parameters = createPriceParameters({});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['product', 'unit_amount', 'currency']);
+    expect(fields.length).toBe(3);
+  });
+
+  it('should return the correct parameters if customer is specified', () => {
+    const parameters = createPriceParameters({customer: 'cus_123'});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['product', 'unit_amount', 'currency']);
+    expect(fields.length).toBe(3);
+  });
+});
+
+describe('listPricesParameters', () => {
+  it('should return the correct parameters if no context', () => {
+    const parameters = listPricesParameters({});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['product', 'limit']);
+    expect(fields.length).toBe(2);
+  });
+
+  it('should return the correct parameters if customer is specified', () => {
+    const parameters = listPricesParameters({customer: 'cus_123'});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['product', 'limit']);
+    expect(fields.length).toBe(2);
+  });
+});
+
+describe('createPaymentLinkParameters', () => {
+  it('should return the correct parameters if no context', () => {
+    const parameters = createPaymentLinkParameters({});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['price', 'quantity']);
+    expect(fields.length).toBe(2);
+  });
+
+  it('should return the correct parameters if customer is specified', () => {
+    const parameters = createPaymentLinkParameters({customer: 'cus_123'});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['price', 'quantity']);
+  });
+});
+
+describe('createInvoiceParameters', () => {
+  it('should return the correct parameters if no context', () => {
+    const parameters = createInvoiceParameters({});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['customer', 'days_until_due']);
+    expect(fields.length).toBe(2);
+  });
+
+  it('should return the correct parameters if customer is specified', () => {
+    const parameters = createInvoiceParameters({customer: 'cus_123'});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['days_until_due']);
+    expect(fields.length).toBe(1);
+  });
+});
+
+describe('listInvoicesParameters', () => {
+  it('should return the correct parameters if no context', () => {
+    const parameters = listInvoicesParameters({});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['customer', 'limit']);
+    expect(fields.length).toBe(2);
+  });
+
+  it('should return the correct parameters if customer is specified', () => {
+    const parameters = listInvoicesParameters({customer: 'cus_123'});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['limit']);
+    expect(fields.length).toBe(1);
+  });
+});
+
+describe('createInvoiceItemParameters', () => {
+  it('should return the correct parameters if no context', () => {
+    const parameters = createInvoiceItemParameters({});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['customer', 'price', 'invoice']);
+    expect(fields.length).toBe(3);
+  });
+
+  it('should return the correct parameters if customer is specified', () => {
+    const parameters = createInvoiceItemParameters({customer: 'cus_123'});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['price', 'invoice']);
+    expect(fields.length).toBe(2);
+  });
+});
+describe('finalizeInvoiceParameters', () => {
+  it('should return the correct parameters if no context', () => {
+    const parameters = finalizeInvoiceParameters({});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['invoice']);
+    expect(fields.length).toBe(1);
+  });
+
+  it('should return the correct parameters if customer is specified', () => {
+    const parameters = finalizeInvoiceParameters({customer: 'cus_123'});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['invoice']);
+    expect(fields.length).toBe(1);
+  });
+});
+
+describe('retrieveBalanceParameters', () => {
+  it('should return the correct parameters if no context', () => {
+    const parameters = retrieveBalanceParameters({});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual([]);
+    expect(fields.length).toBe(0);
+  });
+
+  it('should return the correct parameters if customer is specified', () => {
+    const parameters = retrieveBalanceParameters({customer: 'cus_123'});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual([]);
+    expect(fields.length).toBe(0);
+  });
+});
+
+describe('createRefundParameters', () => {
+  it('should return the correct parameters if no context', () => {
+    const parameters = createRefundParameters({});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['payment_intent', 'amount']);
+    expect(fields.length).toBe(2);
+  });
+
+  it('should return the correct parameters if customer is specified', () => {
+    const parameters = createRefundParameters({customer: 'cus_123'});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['payment_intent', 'amount']);
+    expect(fields.length).toBe(2);
+  });
+});
+
+describe('listPaymentIntentsParameters', () => {
+  it('should return the correct parameters if no context', () => {
+    const parameters = listPaymentIntentsParameters({});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['customer', 'limit']);
+    expect(fields.length).toBe(2);
+  });
+
+  it('should return the correct parameters if customer is specified', () => {
+    const parameters = listPaymentIntentsParameters({customer: 'cus_123'});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['limit']);
+    expect(fields.length).toBe(1);
+  });
+});
+
+describe('searchDocumentationParameters', () => {
+  it('should return the correct parameters if no context', () => {
+    const parameters = searchDocumentationParameters({});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['question', 'language']);
+    expect(fields.length).toBe(2);
+  });
+
+  it('should return the correct parameters if customer is specified', () => {
+    const parameters = searchDocumentationParameters({customer: 'cus_123'});
+
+    const fields = Object.keys(parameters.shape);
+    expect(fields).toEqual(['question', 'language']);
+    expect(fields.length).toBe(2);
+  });
+});

--- a/typescript/src/test/shared/prompt.test.ts
+++ b/typescript/src/test/shared/prompt.test.ts
@@ -1,0 +1,54 @@
+import {
+  createInvoiceItemPrompt,
+  createInvoicePrompt,
+  listInvoicesPrompt,
+  listPaymentIntentsPrompt,
+} from '../../shared/prompts';
+
+describe('createInvoicePrompt', () => {
+  it('should return the correct prompt', () => {
+    const prompt = createInvoicePrompt();
+    expect(prompt).toContain('customer');
+  });
+
+  it('should return the correct prompt when a customer is specified', () => {
+    const prompt = createInvoicePrompt({customer: 'cus_123'});
+    expect(prompt).not.toContain('customer');
+  });
+});
+
+describe('listInvoicesPrompt', () => {
+  it('should return the correct prompt', () => {
+    const prompt = listInvoicesPrompt();
+    expect(prompt).toContain('customer');
+  });
+
+  it('should return the correct prompt when a customer is specified', () => {
+    const prompt = listInvoicesPrompt({customer: 'cus_123'});
+    expect(prompt).not.toContain('customer');
+  });
+});
+
+describe('createInvoiceItemPrompt', () => {
+  it('should return the correct prompt', () => {
+    const prompt = createInvoiceItemPrompt();
+    expect(prompt).toContain('customer');
+  });
+
+  it('should return the correct prompt when a customer is specified', () => {
+    const prompt = createInvoiceItemPrompt({customer: 'cus_123'});
+    expect(prompt).not.toContain('customer');
+  });
+});
+
+describe('listPaymentIntentsPrompt', () => {
+  it('should return the correct prompt', () => {
+    const prompt = listPaymentIntentsPrompt();
+    expect(prompt).toContain('customer');
+  });
+
+  it('should return the correct prompt when a customer is specified', () => {
+    const prompt = listPaymentIntentsPrompt({customer: 'cus_123'});
+    expect(prompt).not.toContain('customer');
+  });
+});


### PR DESCRIPTION
Adds `customer` to Context so that certain operations will always specify a specific customer. This increases the determinism and safety around certain operations. For example, if you are building an agent that is interacting with regards to a specific customer, operations like "List Invoices" or "List Payment Intents" will always force the customer id in those request, rather than attempt to look up the customer or otherwise guess.

```js
const stripeAgentToolkit = new StripeAgentToolkit({
  secretKey: process.env.STRIPE_SECRET_KEY!,
  configuration: {
    context: {
      customer: "cus_123",
    },
  },
});
```