### PR TITLE
[evals] Create more robust testing framework

### DIFF
--- a/evals/.env.example
+++ b/evals/.env.example
@@ -1,6 +1,8 @@
 BRAINTRUST_API_KEY=...
 STRIPE_SECRET_KEY=...
 
+# Enable if your OpenAI API is behind a unix socket proxy:
+# SOCKET_PROXY_PATH=""
 OPENAI_BASE_URL=http://0.0.0.0:8000/v1
 OPENAI_API_KEY=EMPTY
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,6 +1,6 @@
 ## Evals
 
-Set up `.env` file with the following:
+Set up `.env` file with the following (see `.env.example` for an example):
 
 ```
 BRAINTRUST_API_KEY=...
@@ -16,3 +16,48 @@ tsx eval.ts
 ```
 
 We are using [Braintrust](https://www.braintrust.dev/) to run the evals.
+
+## Framework
+
+There is a very lightweight testing framework built in to make adding new test cases easy that wraps Braintrust.
+
+Add a new test case to `cases.ts`:
+
+```javascript
+test({
+  prompt:
+    "Create a product called 'Test Product' with a description 'A test product for evaluation'",
+  fn: ({ toolCalls, messages }) => [
+    expectToolCall(toolCalls, ["create_product"]),
+    llmCriteriaMet(
+      messages,
+      "The message should include a successful production creation response"
+    ),
+  ],
+});
+```
+
+The Typescript type defintions have documentation to help you. The `fn` function
+will be called with the resulting output of your prompt. This should return an array of "assertions." These are like `expect` in Jest.
+
+This can be as simple as noting a tool was called exist or as complex as asking an LLM to do semantc similarities. See `scorer.ts` for a list of assertions.
+
+Override the toolkit config by passing a `toolkitConfig` object.
+
+If your test case needs some set up, for example, if it needs to set up some state in the Stripe account or load data, you can pass an async function.
+
+```javascript
+test(async () => {
+  const customers = await stripe.customers.list();
+
+  return {
+    prompt: "What are my payments",
+    toolkitConfig: {
+      context: {
+        customer: customers.data[0].id,
+      },
+    },
+    fn: ({ toolCalls, messages }) => [],
+  };
+});
+```

--- a/evals/cases.ts
+++ b/evals/cases.ts
@@ -1,79 +1,140 @@
-import { Assertion } from "./scorer";
+require("dotenv").config();
 
-export const TEST_CASES: {
-  input: string;
-  expected: Assertion[];
-}[] = [
-  {
-    input:
-      "Create a product called 'Test Product' with a description 'A test product for evaluation'",
-    expected: [
-      {
-        path: "messages[1].tool_calls[0].function.name",
-        assertion_type: "equals",
-        value: "create_product",
-      },
-      {
-        path: "responseChatCompletions[0].content",
-        assertion_type: "llm_criteria_met",
-        value:
-          "The message should include a successful product creation response",
-      },
-    ],
+import {
+  assert,
+  EvalCaseFunction,
+  EvalInput,
+  expectToolCall,
+  llmCriteriaMet,
+} from "./scorer";
+import { Configuration as StripeAgentToolkitConfig } from "../typescript/src/shared/configuration";
+import Stripe from "stripe";
+
+/*
+ * A single test case that is used to evaluate the agent.
+ * It contains an input, a toolkit config, and an function to use to run
+ * assertions on the output of the agent. It is structured to be used with
+ * Braintrust.
+ */
+type BraintrustTestCase = {
+  input: EvalInput;
+  toolkitConfig?: StripeAgentToolkitConfig;
+  expected: EvalCaseFunction;
+};
+
+/* This is used in a Braintrust Eval. Our test framework appends new test cases to this array.*/
+const _testCases: Array<BraintrustTestCase | Promise<BraintrustTestCase>> = [];
+
+/*
+ * Helper type for adding test cases to the Braintrust Eval.
+ */
+type TestCaseData = {
+  // The user prompt to pass into the agent.
+  prompt: string;
+  // The function to use to run assertions on the output of the agent.
+  fn: EvalCaseFunction;
+  // Optional toolkit config to set into the agent to override the default set in eval.ts.
+  toolkitConfig?: StripeAgentToolkitConfig;
+};
+
+const argsToTestCase = (args: TestCaseData): BraintrustTestCase => ({
+  input: {
+    toolkitConfigOverride: args.toolkitConfig || {},
+    userPrompt: args.prompt,
   },
-  {
-    input: "List all available products",
-    expected: [
-      {
-        path: "messages[1].tool_calls[0].function.name",
-        assertion_type: "equals",
-        value: "list_products",
+  expected: args.fn,
+});
+
+/*
+ * Helper function for adding test cases to the Braintrust Eval.
+ */
+const test = (args: TestCaseData | (() => Promise<TestCaseData>)) => {
+  if (typeof args == "function") {
+    const promise = args().then(argsToTestCase);
+    _testCases.push(promise);
+  } else {
+    _testCases.push(argsToTestCase(args));
+  }
+};
+
+test({
+  prompt:
+    "Create a product called 'Test Product' with a description 'A test product for evaluation'",
+  fn: ({ toolCalls, messages }) => [
+    expectToolCall(toolCalls, ["create_product"]),
+    llmCriteriaMet(
+      messages,
+      "The message should include a successful production creation response"
+    ),
+  ],
+});
+
+test({
+  prompt: "List all available products",
+  fn: ({ toolCalls, messages }) => [
+    expectToolCall(toolCalls, ["list_products"]),
+    llmCriteriaMet(messages, "The message should include a list of products"),
+  ],
+});
+
+test({
+  prompt:
+    "Create a customer with a name of a Philadelphia Eagles player and email. Charge them $100.",
+  fn: ({ toolCalls, messages }) => [
+    expectToolCall(toolCalls, ["create_customer"]),
+  ],
+});
+
+test({
+  prompt:
+    "Create a payment link for a new product called 'test' with a price of $70. Come up with a haiku for the description.",
+  fn: ({ toolCalls, messages }) => [
+    llmCriteriaMet(
+      messages,
+      "The message should include a successful payment link creation response"
+    ),
+    expectToolCall(toolCalls, ["create_payment_link"]),
+  ],
+});
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+
+test(async () => {
+  const customer = await stripe.customers.create({
+    name: "Joel E",
+    email: "joel@example.com",
+  });
+
+  const joelsPayment = await stripe.paymentIntents.create({
+    amount: 2000,
+    currency: "usd",
+    customer: customer.id,
+  });
+
+  const otherPi = await stripe.paymentIntents.create({
+    amount: 3000,
+    currency: "usd",
+  });
+
+  return {
+    prompt: "List payment intents",
+    toolkitConfig: {
+      context: {
+        customer: customer.id,
       },
-      {
-        path: "messages",
-        assertion_type: "llm_criteria_met",
-        value:
-          "The messages should include a list of products returned from the Stripe API",
-      },
+    },
+    fn: ({ assistantMessages }) => [
+      assert(
+        (function () {
+          return (
+            assistantMessages.some((m) => m.includes(joelsPayment.id)) &&
+            assistantMessages.every((m) => !m.includes(otherPi.id))
+          );
+        })(),
+        `messages only includes customers payment intent ${joelsPayment.id}`
+      ),
     ],
-  },
-  {
-    input:
-      "Create a customer named 'Test Customer' with email 'test@example.com'",
-    expected: [
-      {
-        path: "messages[1].tool_calls[0].function.name",
-        assertion_type: "equals",
-        value: "create_customer",
-      },
-      {
-        path: "messages",
-        assertion_type: "llm_criteria_met",
-        value:
-          "The messages should include a successful customer creation response",
-      },
-    ],
-  },
-  {
-    input:
-      "Create a payment link for a new product called 'test' with a price of $100. Come up with a funny description about buy bots, maybe a haiku.",
-    expected: [
-      {
-        path: "messages",
-        assertion_type: "llm_criteria_met",
-        value:
-          "The messages should include a sequence of: product creation, price creation, and payment link creation",
-      },
-      {
-        path: "responseChatCompletions[0].content",
-        assertion_type: "semantic_contains",
-        value: "payment link",
-      },
-      {
-        path: "responseChatCompletions[0].content",
-        assertion_type: "semantic_contains",
-        value: "haiku",
-      },
-    ],
-  },
-];
+  };
+});
+
+export const getEvalTestCases = async () => Promise.all(_testCases);

--- a/evals/openai.ts
+++ b/evals/openai.ts
@@ -1,0 +1,22 @@
+require("dotenv").config();
+
+import { wrapOpenAI } from "braintrust";
+import OpenAI from "openai";
+import * as http from "http";
+import * as net from "net";
+
+const httpAgent = process.env.SOCKET_PROXY_PATH
+  ? new (class extends http.Agent {
+      createConnection = (_: any, callback: Function) =>
+        net.createConnection(process.env.SOCKET_PROXY_PATH!, () => callback());
+    })()
+  : undefined;
+
+// This wrap function adds useful tracing in Braintrust
+export const openai = wrapOpenAI(
+  new OpenAI({
+    baseURL: process.env.OPENAI_BASE_URL,
+    apiKey: process.env.OPENAI_API_KEY,
+    httpAgent,
+  })
+);

--- a/evals/package.json
+++ b/evals/package.json
@@ -13,11 +13,12 @@
     "@ai-sdk/openai": "^0.0.63",
     "@stripe/agent-toolkit": "file:../typescript",
     "ai": "^4.0.28",
-    "autoevals": "^0.0.121",
+    "autoevals": "^0.0.124",
     "braintrust": "^0.0.185",
     "dotenv": "^16.4.7",
     "lodash": "^4.17.21",
     "openai": "^4.86.1",
+    "stripe": "^17.7.0",
     "zod": "^3.24.2"
   }
 }

--- a/evals/pnpm-lock.yaml
+++ b/evals/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^4.0.28
         version: 4.0.28(react@19.0.0)(zod@3.24.2)
       autoevals:
-        specifier: ^0.0.121
-        version: 0.0.121
+        specifier: ^0.0.124
+        version: 0.0.124
       braintrust:
         specifier: ^0.0.185
         version: 0.0.185(openai@4.86.1(zod@3.24.2))(react@19.0.0)(sswr@2.1.0(svelte@5.21.0))(svelte@5.21.0)(vue@3.5.13)(zod@3.24.2)
@@ -32,6 +32,9 @@ importers:
       openai:
         specifier: ^4.86.1
         version: 4.86.1(zod@3.24.2)
+      stripe:
+        specifier: ^17.7.0
+        version: 17.7.0
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -184,6 +187,9 @@ packages:
 
   '@braintrust/core@0.0.80':
     resolution: {integrity: sha512-vTWV4CfYhOSoV05Ae5ljBVrScty7KcyaZ9p+EFaTj0aDwuEoX2QjFYXumNsn5iV/fb5RicHx9ecZ0uIvXfmY0g==}
+
+  '@braintrust/core@0.0.82':
+    resolution: {integrity: sha512-ZNuVsstz7DJAiWKyLGtcxiviomM57eD+tCTISL5GpEKgOEN4C7hi6hAxgfStt0TGvQ9w5X/FfdgU2i9GwYxrrg==}
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
@@ -504,8 +510,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  autoevals@0.0.121:
-    resolution: {integrity: sha512-1xOhtHesm11VtxAMKB5ezFPFXo7j9TVss7/I9NnLwhgYhsJ3KPiYmXaEq5SGF13K0wcBvWp2UzquY0SOpb4yTw==}
+  autoevals@0.0.124:
+    resolution: {integrity: sha512-uBvQAgwuLgK8R6ayT9m892hU7RRrN4qXj/KIoJBeUuNe79x/VWI1vmopgvn95gHQT1PMu63Wv8FrMmCvyjlYsw==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -1445,6 +1451,12 @@ snapshots:
       uuid: 9.0.1
       zod: 3.24.2
 
+  '@braintrust/core@0.0.82':
+    dependencies:
+      '@asteasolutions/zod-to-openapi': 6.4.0(zod@3.24.2)
+      uuid: 9.0.1
+      zod: 3.24.2
+
   '@cfworker/json-schema@4.1.1': {}
 
   '@esbuild/android-arm64@0.18.20':
@@ -1734,9 +1746,9 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  autoevals@0.0.121:
+  autoevals@0.0.124:
     dependencies:
-      '@braintrust/core': 0.0.80
+      '@braintrust/core': 0.0.82
       ajv: 8.17.1
       compute-cosine-similarity: 1.1.0
       js-levenshtein: 1.1.6


### PR DESCRIPTION
The README has more documentation, but in short:

We can add test cases easily. Here is a simple example:

```ts
test({
  prompt: "List all available products",
  fn: ({ toolCalls, messages }) => [
    expectToolCall(toolCalls, ["list_products"]),
    llmCriteriaMet(messages, "The message should include a list of products"),
  ],
});
```

[The corresponding Braintrust row is here](https://www.braintrust.dev/app/stripe-oss/p/agent-toolkit/experiments/matv%2Fmoreevals-1742486162?c=matv/moreevals-1742420166&r=e227f6d0-1f85-47be-9a3f-ef626064c7cc&s=5e6d446e-eb77-4497-bb93-b11aec355698)

![CleanShot 2025-03-20 at 12 37 48@2x](https://github.com/user-attachments/assets/e6657518-4ca5-4b15-aa20-076b3eae2d6b)

It has useful tracing measurements to see what the agent toolkit responded and what tools were used.
![CleanShot 2025-03-20 at 12 38 34@2x](https://github.com/user-attachments/assets/d1903ce2-739e-47ba-8ccf-3446ee753175)


Here is a more complex example where we want to set up Stripe data and then use a customer in the `context` for the toolkit

```ts
test(async () => {
  const customer = await stripe.customers.create({
    name: "Joel E",
    email: "joel@example.com",
  });

  const joelsPayment = await stripe.paymentIntents.create({
    amount: 2000,
    currency: "usd",
    customer: customer.id,
  });

  const otherPi = await stripe.paymentIntents.create({
    amount: 3000,
    currency: "usd",
  });

  return {
    prompt: "List payment intents",
    toolkitConfig: {
      context: {
        customer: customer.id,
      },
    },
    fn: ({ assistantMessages }) => [
      assert(
        (function () {
          return (
            assistantMessages.some((m) => m.includes(joelsPayment.id)) &&
            assistantMessages.every((m) => !m.includes(otherPi.id))
          );
        })(),
        `messages only includes customers payment intent ${joelsPayment.id}`
      ),
    ],
  };
});
```

This test case has 
1. Async data loading for set up
2. Ability to override the toolkit configuration
3. Ability to easily make assertions on response output
