### PR TITLE
fix: list customers function should return customer objects instead of ids

### DIFF
--- a/typescript/src/shared/customers/functions.ts
+++ b/typescript/src/shared/customers/functions.ts
@@ -31,7 +31,7 @@ export const listCustomers = async (
       context.account ? {stripeAccount: context.account} : undefined
     );
 
-    return customers.data.map((customer) => ({id: customer.id}));
+    return customers.data;
   } catch (error) {
     return 'Failed to list customers';
   }


### PR DESCRIPTION
The lists customers function returns a list of ids which is not usefult in many cases like usage with MCP. Instead of list of id's return the list of customer objects.