### PR TITLE
feat: change MCP tool name for avoiding to the conflict

### DIFF
--- a/typescript/src/modelcontextprotocol/toolkit.ts
+++ b/typescript/src/modelcontextprotocol/toolkit.ts
@@ -35,7 +35,7 @@ class StripeAgentToolkit extends McpServer {
 
     filteredTools.forEach((tool) => {
       this.tool(
-        tool.method,
+        `stripe_${tool.method}`,
         tool.description,
         tool.parameters.shape,
         async (arg: any, _extra: RequestHandlerExtra) => {


### PR DESCRIPTION

Thank you for providing the MCP server. It has been extremely helpful for my Stripe development and research.

## Issue Description
I'd like to request adding a `stripe_` prefix to the MCP server tool names to avoid naming conflicts.

As more companies begin to provide MCP servers, tool name collisions are becoming increasingly common. I've personally encountered this issue between AWS and Stripe MCP servers.

Both currently provide a `search_documentation` tool for documentation searches. When users register both MCP servers, conflicts occur. This leads to degraded developer experience, with Stripe searches being sent to AWS or AWS searches being sent to Stripe, resulting in meaningless search requests being sent to your servers.

![スクリーンショット 2025-04-28 10 46 32](https://github.com/user-attachments/assets/58581aaa-611a-48b2-b9a2-8e5cd0df872c)

# feat: Add `stripe_` prefix to MCP tool names to avoid conflicts


## Proposed Solution
A simple solution would be to add a `stripe_` prefix to your tool names. Your codebase appears well-structured, making this change possible with minimal code modification.

## Benefits
- Improved developer experience when working with multiple MCP servers
- Prevention of misdirected search queries
- Better ecosystem compatibility as MCP adoption grows
- Clearer identification of tool sources

This change would greatly improve the experience for developers using both AWS and Stripe, and help spread adoption of your excellent MCP server to more users.

Thank you for considering this request.