### PR TITLE
Rename search_documentation -> search_stripe_documentation

### DIFF
--- a/typescript/src/shared/documentation/searchDocumentation.ts
+++ b/typescript/src/shared/documentation/searchDocumentation.ts
@@ -60,8 +60,8 @@ export const searchDocumentation = async (
 };
 
 const tool = (context: Context): Tool => ({
-  method: 'search_documentation',
-  name: 'Search Documentation',
+  method: 'search_stripe_documentation',
+  name: 'Search Stripe Documentation',
   description: searchDocumentationPrompt(context),
   parameters: searchDocumentationParameters(context),
   actions: {

--- a/typescript/src/shared/subscriptions/updateSubscription.ts
+++ b/typescript/src/shared/subscriptions/updateSubscription.ts
@@ -4,8 +4,7 @@ import type {Context} from '@/shared/configuration';
 import type {Tool} from '@/shared/tools';
 
 export const updateSubscriptionPrompt = (_context: Context = {}): string => {
-  return `
-  This tool will update an existing subscription in Stripe. If changing an existing subscription item, the existing subscription item has to be set to deleted and the new one has to be added.
+  return `This tool will update an existing subscription in Stripe. If changing an existing subscription item, the existing subscription item has to be set to deleted and the new one has to be added.
   
   It takes the following arguments:
   - subscription (str, required): The ID of the subscription to update.


### PR DESCRIPTION
Fix for the issue described here: https://github.com/stripe/agent-toolkit/pull/64

Ideally, namespacing would be built into the spec to avoid this issue, but I think the underlying issue comes down to how tool calls are passed into the LLM providers.


There is an RFC for this here, but it is still a heavy WIP https://github.com/modelcontextprotocol/modelcontextprotocol/pull/334


I think in the meantime, including `stripe` in the search documentation tool name seems reasonable.

r? @stevekaliski-stripe 

