### PR TITLE
Fix unintended customer retrieval in getCurrentCustomerID

### DIFF
--- a/typescript/src/cloudflare/index.mts
+++ b/typescript/src/cloudflare/index.mts
@@ -50,17 +50,18 @@ export abstract class experimental_PaidMcpAgent<
     if (this.state?.stripe?.customerId) {
       return this.state.stripe.customerId || '';
     }
+    const { userEmail } = this.props;
 
-    const customers = await this.stripe().customers.list({
-      email: this.props.userEmail,
-    });
+    const customers = userEmail ? await this.stripe().customers.list({
+      email: userEmail,
+    }) : {data: []}
 
-    let customerId: null | string = null;
-    if (customers.data.length > 0) {
-      customerId = customers.data[0].id;
-    } else {
+    let customerId: null | string = customers.data.find((customer) => {
+        return customer.email === userEmail
+      })?.id || null;
+    if (!customerId) {
       const customer = await this.stripe().customers.create({
-        email: this.props.userEmail,
+        email: userEmail,
       });
 
       customerId = customer.id;


### PR DESCRIPTION

Fixes #82

The `getCurrentCustomerID` function in the `@stripe/agent-toolkit/cloudflare` package had an unintended behavior that could lead to retrieving ALL customers when `userEmail` is null or undefined. This could potentially create checkout sessions for incorrect customers.

## Changes

This PR modifies the `getCurrentCustomerID` function to:

1. Add proper handling when `userEmail` is null or undefined by returning an empty data array instead of fetching all customers
2. Ensure exact email matching when searching for a customer in the retrieved list
3. Prevent unintended customer selection by using explicit email comparison

## Testing

Tested the changes by verifying that:
- When `userEmail` is undefined, no customer list API call is made
- When customers are retrieved, only the exact email match is selected
- When no matching customer is found, a new customer is created as expected

## Additional Notes

This change eliminates the risk of:
- Creating checkout sessions for unintended customers
- Displaying other customers' email addresses in checkout forms
- Inconsistent checkout experiences
