### PR TITLE
Allow passing additional subscription data (e.g. trial, metadata) to Checkout Session

### DIFF
--- a/typescript/src/cloudflare/index.mts
+++ b/typescript/src/cloudflare/index.mts
@@ -83,11 +83,13 @@ export abstract class experimental_PaidMcpAgent<
       paymentReason,
       successUrl,
       meterEvent,
+      subscriptionData,
     }: {
       priceId: string;
       paymentReason: string;
       successUrl: string;
       meterEvent?: string;
+      subscriptionData?: Stripe.Checkout.SessionCreateParams.SubscriptionData;
     }
   ) {
     const mcpServer: McpServer = this.server as unknown as McpServer;
@@ -154,6 +156,7 @@ export abstract class experimental_PaidMcpAgent<
                   quantity: 1,
                 },
               ],
+              subscription_data: subscriptionData,
               mode: 'subscription',
               customer: customerId || undefined,
             });
@@ -206,6 +209,7 @@ export abstract class experimental_PaidMcpAgent<
               },
             ],
             mode: 'subscription',
+            subscription_data: subscriptionData,
             customer: customerId || undefined,
           });
 


### PR DESCRIPTION

This PR enables passing extra subscription data such as `trial_period_days`, `metadata`, and other fields to the Stripe Checkout Session when creating a subscription. This allows for more flexible subscription management, including support for trials and custom metadata.

## Motivation

Currently, the Checkout Session for subscriptions does not support passing additional subscription parameters. This change allows users to specify fields like `trial_period_days` and `metadata` via the `subscriptionData` option, making the integration more versatile.

## Changes

- Add support for passing `subscription_data` to the Stripe Checkout Session creation call.
- No breaking changes; existing usage remains compatible.

## Example

You can now pass additional subscription options like this:

```ts
paidTool('toolName', schema, callback, {
  priceId: 'price_xxx',
  paymentReason: 'Access to tool',
  successUrl: 'https://example.com/success',
  subscriptionData: {
    trial_period_days: 14,
    metadata: { plan: 'pro' }
  }
});
```
