### PR TITLE
[automated release] remove provenance flag and add ignore scripts

### DIFF
--- a/.github/workflows/npm_release.yml
+++ b/.github/workflows/npm_release.yml
@@ -28,7 +28,7 @@ jobs:
       - run: pnpm install
       - run: pnpm run test
       - run: pnpm run build
-      - run: npm publish --provenance --access public
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -56,6 +56,6 @@ jobs:
       - run: pnpm install
       - run: pnpm run test
       - run: pnpm run build
-      - run: npm publish --provenance --access public
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm_release.yml
+++ b/.github/workflows/npm_release.yml
@@ -28,7 +28,7 @@ jobs:
       - run: pnpm install
       - run: pnpm run test
       - run: pnpm run build
-      - run: npm publish --access public
+      - run: npm publish --ignore-scripts --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -56,6 +56,6 @@ jobs:
       - run: pnpm install
       - run: pnpm run test
       - run: pnpm run build
-      - run: npm publish --access public
+      - run: npm publish --ignore-scripts --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Getting this error
```
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=214191563
npm error code E422
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@stripe%2fmcp - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/stripe/agent-toolkit" from provenance
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-05-16T18_24_08_500Z-debug-0.log
```