### PR TITLE
Gemini CLI Extension manifest for Stripe's MCP remote server

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -2,7 +2,7 @@
   "name": "@stripe/gemini-mcp-extension",
   "version": "0.1.0",
   "mcpServers": {
-    "stripeMcp": {
+    "stripe": {
       "httpUrl": "https://mcp.stripe.com",
       "oauth": {
         "enabled": true


### PR DESCRIPTION
Adds a manifest file for Gemini CLI users to install an extension for it to talk to Stripe's MCP remote server as per https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md. 

NOTE: Gemini CLI expects `gemini-extension.json` to be at the top level directory of a public repo

NOTE: This currently requires an update to the Gemini CLI (https://github.com/google-gemini/gemini-cli/pull/9231/files) or Stripe exposing `.well-known/oauth-authorization-server` at `marketplace.stripe.com` which are being handled in separate PRs

Testing:
 - I tested this with the manifest file at a top-level of a public repo via `gemini extensions install <a public repo>` with the changes mentioned above, authed the app, and was able to list products, locally