### PR TITLE
rename manifest name to fix gemini cli writing it to that dir name

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stripe/gemini-mcp-extension",
+  "name": "stripe-gemini-mcp-extension",
   "version": "0.1.0",
   "mcpServers": {
     "stripe": {


### PR DESCRIPTION
gemini-cli uses the manifest's name as the folder name to write to `~/.gemini/extensions/{manifest name}` which conflicts with npm's scoped package naming since we have `/` in it