### PR TITLE
Rename Gemini CLI extension from 'stripe-gemini-mcp-extension' to 'stripe'

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
-  "name": "stripe-gemini-mcp-extension",
+  "name": "stripe",
   "version": "0.1.0",
   "mcpServers": {
     "stripe": {


### PR DESCRIPTION
Gemini CLI extensions should just be the name of the partner (`stripe`)

This way users can update with `gemini extensions update stripe` etc and not need to type in full name.

It is redundant to have the long name :)