### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
 jobs:
   typescript-build:
     name: Build - TypeScript


### PR DESCRIPTION
Potential fix for [https://github.com/stripe/agent-toolkit/security/code-scanning/4](https://github.com/stripe/agent-toolkit/security/code-scanning/4)

The recommended fix is to add a `permissions:` block to the workflow at the top level, before the `jobs:` key. This sets permissions for all jobs that do not have their own explicit `permissions` block. The minimal recommended setting for typical build, test, and CI jobs is `contents: read`, which allows jobs to fetch repository contents (needed by actions/checkout) but does not grant write abilities. This change should be added between the workflow triggers (`on:` ...) and the `jobs:` block in `.github/workflows/main.yml`. No imports or additional changes are required; adding these lines will ensure least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
