### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   workflow_dispatch: {}


### PR DESCRIPTION
Potential fix for [https://github.com/stripe/agent-toolkit/security/code-scanning/3](https://github.com/stripe/agent-toolkit/security/code-scanning/3)

To fix this issue, you should explicitly add a `permissions` block to each job (or to the workflow root) in `.github/workflows/main.yml`. The block should specify only the minimum required permissions. For these build and test jobs, the minimal permission is usually `contents: read` (since they need to check out code, but do not need to write to the repository or interact with other resources). You should add:

```yaml
permissions:
  contents: read
```

to each job under its definition (directly beneath the job's name and runs-on keys), or place it at the root of the workflow to apply to all jobs. Given that all jobs shown require only minimal permissions, the most straightforward approach is to add the block at the top level, just after the `name` field and before `on:`. This ensures all jobs inherit the restrictive permissions unless overridden locally.

No new packages or methods are required. You only need to update the YAML workflow file to include the correct permissions block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
