### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   workflow_dispatch: {}


### PR DESCRIPTION
Potential fix for [https://github.com/stripe/agent-toolkit/security/code-scanning/2](https://github.com/stripe/agent-toolkit/security/code-scanning/2)

To fix the problem, we should add a `permissions` block to the workflow to limit the permissions that the GITHUB_TOKEN grants. The least privilege required for build/test workflows such as these is usually `contents: read`, as none of the jobs perform write operations on the repository or interact with pull requests/issues. This can be done at the root of the YAML file (top-level), ensuring all jobs get read-only permissions unless further permissions are explicitly required for any particular job. 

The fix is implemented as follows:
- Insert a top-level `permissions:` block specifying `contents: read` immediately after the workflow `name` key and before the `on:` trigger block.
No other changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
