### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -8,6 +8,8 @@ jobs:
     name: Build for PyPi
     runs-on: ubuntu-latest
     environment: pypi
+    permissions:
+      contents: read
 
     defaults:
       run:


### PR DESCRIPTION
Potential fix for [https://github.com/stripe/agent-toolkit/security/code-scanning/1](https://github.com/stripe/agent-toolkit/security/code-scanning/1)

To fix the problem, add a `permissions` block to the `python-build` job in the workflow YAML file, specifying the minimal required permissions (likely just `contents: read`). This ensures that the job's GITHUB_TOKEN is limited to only reading repository contents, reducing the risk of accidental or malicious modification of repository resources. The change should be made within the `.github/workflows/pypi_release.yml` file, directly in the `python-build` job definition, ideally immediately following the `runs-on:` and `environment:` lines for clarity and convention. No further changes, imports, or definitions are needed; this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
