### PR TITLE
Publish to MCP Registry

### DIFF
--- a/tools/modelcontextprotocol/server.json
+++ b/tools/modelcontextprotocol/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
-  "name": "com.stripe.mcp",
-  "description": "Model Context Protocol server for integrating with Stripe APIs through function calling. Supports customers, products, subscriptions, payments, and more.",
+  "name": "com.stripe/mcp",
+  "description": "MCP server integrating with Stripe - tools for customers, products, payments, and more.",
   "repository": {
     "url": "https://github.com/stripe/agent-toolkit",
     "source": "github"


### PR DESCRIPTION
This PR registers the Stripe MCP remote server with the MCP Registry:
- **Remote**: mcp.stripe.com

This follows the [Publishing Your MCP Server](https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/publish-server.md#publish-your-mcp-server) guide.

## Checklist
- [x] [Authenticate custom DNS](https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/publish-server.md#step-4-authenticate) for remote registration

## Publish
```
❯ curl "https://registry.modelcontextprotocol.io/v0/servers?search=com.stripe" | jq
{
  "servers": [
    {
      "server": {
        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
        "name": "com.stripe/mcp",
        "description": "MCP server integrating with Stripe - tools for customers, products, payments, and more.",
        "repository": {
          "url": "https://github.com/stripe/agent-toolkit",
          "source": "github"
        },
        "version": "0.2.4",
        "remotes": [
          {
            "type": "streamable-http",
            "url": "https://mcp.stripe.com"
          }
        ]
      },
      "_meta": {
        "io.modelcontextprotocol.registry/official": {
          "status": "active",
          "publishedAt": "2025-10-28T22:06:18.495159Z",
          "updatedAt": "2025-10-28T22:06:18.495159Z",
          "isLatest": true
        }
      }
    }
  ],
  "metadata": {
    "count": 1
  }
}
```