### PR TITLE
Update package peer dependencies and version

### DIFF
--- a/llm/ai-sdk/package.json
+++ b/llm/ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/ai-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Stripe AI SDK - Provider and metering utilities for Vercel AI SDK",
   "exports": {
     "./provider": {
@@ -64,9 +64,9 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@ai-sdk/anthropic": "^1.0.5",
-    "@ai-sdk/google": "^1.0.9",
-    "@ai-sdk/openai": "^1.0.8",
+    "@ai-sdk/anthropic": "^2.0.41",
+    "@ai-sdk/google": "^2.0.27",
+    "@ai-sdk/openai": "^2.0.59",
     "ai": "^3.4.7 || ^4.0.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Currently the peer dependencies for the AI SDK are a major version behind, which causes an error on install and requires using --legacy-peer-deps in order to make it work. This updates the package version to fix that issue. 