### PR TITLE
Update mcp_header for TypeScript

### DIFF
--- a/tools/typescript/src/shared/constants.ts
+++ b/tools/typescript/src/shared/constants.ts
@@ -8,4 +8,4 @@ declare const process: {env: {PACKAGE_VERSION?: string}};
 export const VERSION = process.env.PACKAGE_VERSION || '0.0.0-development';
 export const MCP_SERVER_URL = 'https://mcp.stripe.com';
 export const TOOLKIT_HEADER = 'stripe-agent-toolkit-typescript';
-export const MCP_HEADER = 'stripe-mcp-local';
+export const MCP_HEADER = 'stripe-mcp-typescript';


### PR DESCRIPTION
Python uses `stripe-mcp-python`, modelcontextprotocol uses `stripe-mcp-local`, updating this to match the pattern and be more descriptive in metrics