### PR TITLE
Update npm release workflow

### DIFF
--- a/.github/workflows/npm_release_shared.yml
+++ b/.github/workflows/npm_release_shared.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+
     steps:
       - uses: actions/checkout@v4
 
@@ -30,15 +31,16 @@ jobs:
         with:
           version: 9.11.0
 
-      # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
+
+      - run: node --version
+      - run: npm --version
 
       - run: pnpm install
       - run: pnpm run --if-present test
       - run: pnpm run --if-present build
+
       - run: npm publish --ignore-scripts --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
**Migrate to OIDC**
We've updated our NPM package to use OIDC, now we remove the auth token usage during publishing.

**Use newer Node version**
OIDC requires a at least Node 22.14.0 and npm 11.5.1. This PR bumps the node version to 24, and adds version checking for extra debugging.