### PR TITLE
Add repository information to mcp and typescript packages

### DIFF
--- a/tools/modelcontextprotocol/package.json
+++ b/tools/modelcontextprotocol/package.json
@@ -28,6 +28,10 @@
     "@modelcontextprotocol/sdk": "^1.17.1",
     "colors": "^1.4.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stripe/ai"
+  },
   "keywords": [
     "mcp",
     "modelcontextprotocol",

--- a/tools/typescript/package.json
+++ b/tools/typescript/package.json
@@ -42,6 +42,10 @@
   "engines": {
     "node": ">=18"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stripe/ai"
+  },
   "author": "Stripe <support@stripe.com> (https://stripe.com/)",
   "contributors": [
     "Steve Kaliski <stevekaliski@stripe.com>"


### PR DESCRIPTION
For npm publishing, OIDC requires repository.url to match our url