### PR TITLE
Fix broken npm publish by including missing dist/cli.js

### DIFF
--- a/tools/modelcontextprotocol/package.json
+++ b/tools/modelcontextprotocol/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@stripe/mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "homepage": "https://github.com/stripe/ai/tree/main/tools/modelcontextprotocol",
   "description": "A command line tool for setting up Stripe MCP server",
   "bin": "dist/index.js",
   "files": [
     "dist/index.js",
+    "dist/cli.js",
     "LICENSE",
     "README.md",
     "VERSION",

--- a/tools/modelcontextprotocol/src/index.ts
+++ b/tools/modelcontextprotocol/src/index.ts
@@ -11,7 +11,7 @@ import {
 } from './cli';
 
 const MCP_SERVER_URL = 'https://mcp.stripe.com';
-const VERSION = '0.3.0';
+const VERSION = '0.3.1';
 const USER_AGENT = `stripe-mcp-local/${VERSION}`;
 
 function handleError(error: unknown): void {


### PR DESCRIPTION
 ### Summary

  - The 0.3.0 release to npm was broken because dist/cli.js was missing from the files array in package.json. dist/index.js imports from ./cli at runtime, so the package fails
   immediately on use.
  - Added dist/cli.js to files and bumped version to 0.3.1.

###  Test plan

  - Run npm pack --dry-run and confirm dist/cli.js is included in the tarball
  - After merge, trigger the "NPM Release" workflow for ./tools/modelcontextprotocol
  - Verify npx @stripe/mcp@0.3.1 --api-key=rk_test_xxx runs without MODULE_NOT_FOUND error
  - Deprecate 0.3.0 on npm


Confirming what files will be published:
```
ai/tools/modelcontextprotocol ❯ npm pack --dry-run
npm notice
npm notice 📦  @stripe/mcp@0.3.1
npm notice Tarball Contents
npm notice 2.9kB README.md
npm notice 2.6kB dist/cli.js
npm notice 3.1kB dist/index.js
npm notice 1.9kB package.json
npm notice Tarball Details
npm notice name: @stripe/mcp
npm notice version: 0.3.1
...
npm notice total files: 4
npm notice
stripe-mcp-0.3.1.tgz
```