### PR TITLE
Add Stripe logo to Cursor plugin

### DIFF
--- a/providers/cursor/plugin/.cursor-plugin/plugin.json
+++ b/providers/cursor/plugin/.cursor-plugin/plugin.json
@@ -9,5 +9,6 @@
   "homepage": "https://docs.stripe.com",
   "repository": "https://github.com/stripe/ai",
   "license": "MIT",
-  "keywords": ["stripe", "payments", "webhooks", "api", "security"]
+  "keywords": ["stripe", "payments", "webhooks", "api", "security"],
+  "logo": "assets/logo.svg"
 }

--- a/providers/cursor/plugin/assets/logo.svg
+++ b/providers/cursor/plugin/assets/logo.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 500 500">
+  <!-- Generator: Adobe Illustrator 29.7.1, SVG Export Plug-In . SVG Version: 2.1.1 Build 8)  -->
+  <defs>
+    <style>
+      .st0 {
+        fill: #533afd;
+        fill-rule: evenodd;
+      }
+    </style>
+  </defs>
+  <path class="st0" d="M125,375l250-52.6V125l-250,51.6v198.4Z"/>
+</svg>


### PR DESCRIPTION
Update Stripe logo to use the parallelogram
https://stripe-brand.com/logo-system

Guide: https://cursorai.notion.site/Building-Plugins-for-Cursor-2f7da74ef04580228fbbf20ecf477a55 