### PR TITLE
Add missing name fields to skills frontmatter

### DIFF
--- a/skills/stripe-best-practices/SKILL.md
+++ b/skills/stripe-best-practices/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: stripe-best-practices
 description: Best practices for building Stripe integrations
 alwaysApply: false
 ---

--- a/skills/upgrade-stripe/SKILL.md
+++ b/skills/upgrade-stripe/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: upgrade-stripe
 description: Guide for upgrading Stripe API versions and SDKs
 alwaysApply: false
 ---


### PR DESCRIPTION
## Summary
- add 
ame to skills/stripe-best-practices/SKILL.md
- add 
ame to skills/upgrade-stripe/SKILL.md

## Why
Some skill loaders expect standard SKILL.md frontmatter to include both 
ame and description. These files already had frontmatter delimiters and description, but no 
ame, which can cause compatibility issues in stricter installers/parsers.

## Scope
Minimal change only: preserve existing content and behavior, just add the missing metadata key.