### PR TITLE
Add AG2 (formerly AutoGen) toolkit adapter and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See [MCP](/tools/modelcontextprotocol) for more details.
 
 ## Agent toolkit
 
-Stripe's Agent Toolkit enables popular agent frameworks including OpenAI's Agent SDK, LangChain, CrewAI, and Vercel's AI SDK to integrate with Stripe APIs through function calling. The library is not exhaustive of the entire Stripe API. It includes support for Python and TypeScript, and is built directly on top of the Stripe [Python][python-sdk] and [Node][node-sdk] SDKs.
+Stripe's Agent Toolkit enables popular agent frameworks including OpenAI's Agent SDK, LangChain, CrewAI, AG2, and Vercel's AI SDK to integrate with Stripe APIs through function calling. The library is not exhaustive of the entire Stripe API. It includes support for Python and TypeScript, and is built directly on top of the Stripe [Python][python-sdk] and [Node][node-sdk] SDKs.
 
 Included below are basic instructions, but refer to [Python](/tools/python) and [TypeScript](/tools/typescript) packages for more information.
 
@@ -60,7 +60,7 @@ async def main():
     await toolkit.close()  # Clean up when done
 ```
 
-The toolkit works with OpenAI's Agent SDK, LangChain, and CrewAI and can be passed as a list of tools. For example:
+The toolkit works with OpenAI's Agent SDK, LangChain, CrewAI, and AG2 (formerly AutoGen) and can be passed as a list of tools. For example:
 
 ```python
 from agents import Agent
@@ -77,7 +77,7 @@ async def main():
     await toolkit.close()
 ```
 
-Examples for OpenAI's Agent SDK,LangChain, and CrewAI are included in [/examples](/tools/python/examples).
+Examples for OpenAI's Agent SDK, LangChain, CrewAI, and AG2 are included in [/examples](/tools/python/examples).
 
 ##### Context
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -10,7 +10,7 @@ For a local MCP, see the [MCP](/modelcontextprotocol) package.
 
 ## Agent Toolkit
 
-The Stripe Agent Toolkit enables popular agent frameworks including Model Context Protocol (MCP), OpenAI's Agent SDK, LangChain, CrewAI, and Vercel's AI SDK to integrate with Stripe APIs through function calling. The
+The Stripe Agent Toolkit enables popular agent frameworks including Model Context Protocol (MCP), OpenAI's Agent SDK, LangChain, CrewAI, AG2, and Vercel's AI SDK to integrate with Stripe APIs through function calling. The
 library is not exhaustive of the entire Stripe API. It includes support for MCP, Python, and TypeScript and is built directly on top of the Stripe [Python][python-sdk] and [Node][node-sdk] SDKs.
 
 Included below are basic instructions, but refer to [Python](/tools/python), [TypeScript](/tools/typescript) packages for more information.

--- a/tools/python/README.md
+++ b/tools/python/README.md
@@ -1,6 +1,6 @@
 # Stripe Agent Toolkit - Python
 
-The Stripe Agent Toolkit library enables popular agent frameworks including OpenAI's Agent SDK, LangChain, and CrewAI to integrate with Stripe APIs through function calling. The
+The Stripe Agent Toolkit library enables popular agent frameworks including OpenAI's Agent SDK, LangChain, CrewAI, and AG2 to integrate with Stripe APIs through function calling. The
 library is not exhaustive of the entire Stripe API. It is built directly on top
 of the [Stripe Python SDK][python-sdk].
 
@@ -49,7 +49,34 @@ async def main():
     await toolkit.close()
 ```
 
-Examples for OpenAI's Agent SDK, LangChain, and CrewAI are included in [/examples](/examples).
+Examples for OpenAI's Agent SDK, LangChain, CrewAI, and AG2 are included in [/examples](/examples).
+
+### AG2 (formerly AutoGen)
+
+```python
+import asyncio
+from stripe_agent_toolkit.ag2.toolkit import create_stripe_agent_toolkit
+
+async def main():
+    toolkit = await create_stripe_agent_toolkit(
+        secret_key="rk_test_...",
+    )
+    tools = toolkit.get_tools()
+
+    from autogen import ConversableAgent, LLMConfig
+    llm_config = LLMConfig({"model": "gpt-4.1-mini", "api_key": "..."})
+    agent = ConversableAgent(
+        name="billing",
+        system_message="You handle billing with Stripe.",
+        llm_config=llm_config,
+    )
+    for tool in tools:
+        tool.register_tool(agent)
+
+    await toolkit.close()
+
+asyncio.run(main())
+```
 
 [python-sdk]: https://github.com/stripe/stripe-python
 [api-keys]: https://dashboard.stripe.com/account/apikeys

--- a/tools/python/examples/ag2/README.md
+++ b/tools/python/examples/ag2/README.md
@@ -1,0 +1,31 @@
+# AG2 Example
+
+Customer support triage with billing integration using
+AG2 (formerly AutoGen). Demonstrates AG2's handoff system
+for routing queries to specialized agents with Stripe tools.
+
+## Handoff Types Demonstrated
+
+- **Context-based** — VIP customers bypass triage
+- **Tool-based** — `classify_query` routes by keyword,
+  returning `ReplyResult` with the target agent
+- **After-work** — agents terminate after responding
+
+## Setup
+
+```bash
+pip install "stripe-agent-toolkit[ag2]"
+pip install python-dotenv
+```
+
+## Environment Variables
+
+- `OPENAI_API_KEY` — OpenAI API key
+- `STRIPE_SECRET_KEY` — Stripe restricted key (`rk_*` recommended)
+- `OPENAI_MODEL` — model name (default: `gpt-4.1-mini`)
+
+## Run
+
+```bash
+python main.py
+```

--- a/tools/python/examples/ag2/main.py
+++ b/tools/python/examples/ag2/main.py
@@ -1,0 +1,183 @@
+"""AG2 (formerly AutoGen) — Customer support with Stripe billing.
+
+Demonstrates AG2's intelligent handoff system routing customer
+queries to a billing agent equipped with Stripe tools.
+
+Three handoff types are shown:
+  - Context-based: VIP customers fast-track to billing
+  - Tool-based: classify_query routes by keyword via ReplyResult
+  - After-work: agents terminate after responding
+"""
+
+import asyncio
+import os
+from typing import Annotated
+
+from dotenv import load_dotenv
+from autogen import ConversableAgent, LLMConfig
+from autogen.agentchat import initiate_group_chat
+from autogen.agentchat.group.patterns import DefaultPattern
+from autogen.agentchat.group import (
+    AgentTarget,
+    ContextVariables,
+    ExpressionContextCondition,
+    ContextExpression,
+    OnContextCondition,
+    ReplyResult,
+    TerminateTarget,
+)
+
+from stripe_agent_toolkit.ag2.toolkit import (
+    create_stripe_agent_toolkit,
+)
+
+load_dotenv()
+
+llm_config = LLMConfig(
+    {
+        "model": os.getenv("OPENAI_MODEL", "gpt-4.1-mini"),
+        "api_key": os.environ["OPENAI_API_KEY"],
+    }
+)
+
+
+async def main():
+    toolkit = await create_stripe_agent_toolkit(
+        secret_key=os.environ["STRIPE_SECRET_KEY"],
+    )
+
+    try:
+        # --- Agents ---
+
+        billing_agent = ConversableAgent(
+            name="billing_agent",
+            system_message=(
+                "You are a billing support specialist with "
+                "access to Stripe. Help customers with "
+                "invoice lookups, charge inquiries, refunds, "
+                "and payment links. Use the available Stripe "
+                "tools to resolve their request."
+            ),
+            llm_config=llm_config,
+        )
+
+        for tool in toolkit.get_tools():
+            tool.register_tool(billing_agent)
+
+        support_agent = ConversableAgent(
+            name="support_agent",
+            system_message=(
+                "You are a general support agent. Handle "
+                "technical questions, account issues, and "
+                "general inquiries."
+            ),
+            llm_config=llm_config,
+        )
+
+        # --- Tool-based handoff ---
+
+        def classify_query(
+            query: Annotated[str, "The customer query to classify"],
+            context_variables: ContextVariables,
+        ) -> ReplyResult:
+            """Classify a customer query and route it."""
+            billing_keywords = [
+                "invoice",
+                "charge",
+                "payment",
+                "refund",
+                "subscription",
+                "billing",
+                "price",
+                "cost",
+                "overcharged",
+                "receipt",
+            ]
+            if any(kw in query.lower() for kw in billing_keywords):
+                context_variables["issue_type"] = "billing"
+                return ReplyResult(
+                    message="Billing issue detected. "
+                    "Routing to billing support.",
+                    target=AgentTarget(billing_agent),
+                    context_variables=context_variables,
+                )
+            context_variables["issue_type"] = "general"
+            return ReplyResult(
+                message="General inquiry. Routing to support.",
+                target=AgentTarget(support_agent),
+                context_variables=context_variables,
+            )
+
+        triage_agent = ConversableAgent(
+            name="triage_agent",
+            system_message=(
+                "You are a support triage agent. Use "
+                "classify_query to route the customer to "
+                "the right team. Do not attempt to solve "
+                "issues yourself."
+            ),
+            llm_config=llm_config,
+            functions=[classify_query],
+        )
+
+        # --- Context-based handoff ---
+        # VIP customers bypass triage, go to billing.
+
+        triage_agent.handoffs.add_context_conditions(
+            [
+                OnContextCondition(
+                    target=AgentTarget(billing_agent),
+                    condition=ExpressionContextCondition(
+                        expression=ContextExpression(
+                            "${customer_tier} == 'vip'"
+                        ),
+                    ),
+                )
+            ]
+        )
+
+        # --- After-work ---
+
+        billing_agent.handoffs.set_after_work(TerminateTarget())
+        support_agent.handoffs.set_after_work(TerminateTarget())
+
+        # --- Run ---
+
+        context = ContextVariables(
+            data={
+                "customer_tier": "standard",
+                "issue_type": "",
+            }
+        )
+
+        user = ConversableAgent(name="user", human_input_mode="NEVER")
+
+        pattern = DefaultPattern(
+            initial_agent=triage_agent,
+            agents=[
+                triage_agent,
+                billing_agent,
+                support_agent,
+            ],
+            user_agent=user,
+            context_variables=context,
+            group_after_work=TerminateTarget(),
+        )
+
+        result, final_context, last_agent = initiate_group_chat(
+            pattern=pattern,
+            messages="I was overcharged on my last "
+            "invoice. Can you look up recent charges "
+            "and help me with a refund?",
+            max_rounds=10,
+        )
+
+        print("\n--- Conversation Complete ---")
+        print(f"Last agent: {last_agent.name}")
+        print(f"Issue type: {final_context.get('issue_type', 'unknown')}")
+    finally:
+        await toolkit.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tools/python/pyproject.toml
+++ b/tools/python/pyproject.toml
@@ -19,11 +19,13 @@ openai = ["openai>=1.0.0", "agents>=0.0.84"]
 langchain = ["langchain>=0.1.0"]
 crewai = ["crewai>=0.1.0"]
 strands = ["strands>=0.1.0"]
+ag2 = ["ag2>=0.11.0"]
 all = [
     "stripe-agent-toolkit[openai]",
     "stripe-agent-toolkit[langchain]",
     "stripe-agent-toolkit[crewai]",
     "stripe-agent-toolkit[strands]",
+    "stripe-agent-toolkit[ag2]",
 ]
 dev = [
     "pytest>=7.0.0",

--- a/tools/python/stripe_agent_toolkit/ag2/__init__.py
+++ b/tools/python/stripe_agent_toolkit/ag2/__init__.py
@@ -1,0 +1,5 @@
+"""Stripe Agent Toolkit for AG2 (formerly AutoGen)."""
+
+from .toolkit import StripeAgentToolkit, create_stripe_agent_toolkit
+
+__all__ = ["StripeAgentToolkit", "create_stripe_agent_toolkit"]

--- a/tools/python/stripe_agent_toolkit/ag2/toolkit.py
+++ b/tools/python/stripe_agent_toolkit/ag2/toolkit.py
@@ -1,0 +1,102 @@
+"""Stripe Agent Toolkit for AG2 (formerly AutoGen)."""
+
+import asyncio
+import concurrent.futures
+from typing import Any
+
+from autogen.tools import Tool
+
+from ..shared.toolkit_core import ToolkitCore
+from ..shared.mcp_client import McpTool
+from ..configuration import Configuration
+
+
+class StripeAgentToolkit(ToolkitCore[list[Tool]]):
+    """Stripe Agent Toolkit for AG2 (formerly AutoGen).
+
+    Example:
+        toolkit = await create_stripe_agent_toolkit(
+            secret_key='rk_test_...',
+        )
+        tools = toolkit.get_tools()
+
+        from autogen import ConversableAgent
+        agent = ConversableAgent(name="billing", llm_config=llm_config)
+        for tool in tools:
+            tool.register_tool(agent)
+
+        await toolkit.close()
+    """
+
+    def __init__(
+        self,
+        secret_key: str,
+        configuration: Configuration | None = None,
+    ):
+        super().__init__(secret_key, configuration)
+        self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=4)
+
+    def _empty_tools(self) -> list[Tool]:
+        return []
+
+    def _convert_tools(self, mcp_tools: list[McpTool]) -> list[Tool]:
+        return [self._create_tool(t) for t in mcp_tools]
+
+    def _create_tool(self, mcp_tool: McpTool) -> Tool:
+        tool_name = mcp_tool["name"]
+        description = mcp_tool.get("description", tool_name)
+        run = self.run_tool
+        executor = self._executor
+
+        def call_stripe(**kwargs: Any) -> str:
+            """Execute a Stripe tool via MCP."""
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                return asyncio.run(run(tool_name, kwargs))
+            # Already in async context — run in thread pool
+            future = executor.submit(asyncio.run, run(tool_name, kwargs))
+            return future.result()
+
+        call_stripe.__name__ = tool_name
+        call_stripe.__doc__ = description
+
+        return Tool(
+            name=tool_name,
+            description=description,
+            func_or_tool=call_stripe,
+            parameters_json_schema=mcp_tool.get("inputSchema"),
+        )
+
+    async def close(self) -> None:
+        """Close MCP connection and thread pool."""
+        self._executor.shutdown(wait=False)
+        await super().close()
+
+    @property
+    def tools(self) -> list[Tool]:
+        """
+        The tools available in the toolkit.
+
+        .. deprecated::
+            Access tools via get_tools() after calling initialize().
+        """
+        return self._get_tools_with_warning()
+
+
+async def create_stripe_agent_toolkit(
+    secret_key: str,
+    configuration: Configuration | None = None,
+) -> StripeAgentToolkit:
+    """Create and initialize a StripeAgentToolkit for AG2.
+
+    Args:
+        secret_key: Stripe API key (rk_* recommended over sk_*)
+        configuration: Optional Stripe configuration
+
+    Returns:
+        Initialized StripeAgentToolkit
+    """
+    toolkit = StripeAgentToolkit(secret_key, configuration)
+    await toolkit.initialize()
+    return toolkit

--- a/tools/python/tests/test_ag2_toolkit.py
+++ b/tools/python/tests/test_ag2_toolkit.py
@@ -1,0 +1,112 @@
+"""Tests for the AG2 toolkit adapter."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from stripe_agent_toolkit.ag2.toolkit import (
+    StripeAgentToolkit,
+    create_stripe_agent_toolkit,
+)
+
+
+@pytest.fixture
+def mock_mcp_client():
+    client = MagicMock()
+    client.connect = AsyncMock()
+    client.disconnect = AsyncMock()
+    client.call_tool = AsyncMock(return_value='{"id": "ch_123"}')
+    return client
+
+
+@pytest.fixture
+def toolkit(mock_mcp_client):
+    with patch(
+        "stripe_agent_toolkit.shared.toolkit_core.StripeMcpClient",
+        return_value=mock_mcp_client,
+    ):
+        return StripeAgentToolkit("rk_test_key")
+
+
+MCP_TOOLS = [
+    {
+        "name": "list_charges",
+        "description": "List recent charges",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "description": "Number of charges",
+                },
+            },
+            "required": ["limit"],
+        },
+    },
+    {
+        "name": "create_refund",
+        "description": "Create a refund",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "charge": {
+                    "type": "string",
+                    "description": "Charge ID to refund",
+                },
+            },
+            "required": ["charge"],
+        },
+    },
+]
+
+
+class TestEmptyTools:
+    def test_returns_empty_list(self, toolkit):
+        assert toolkit._empty_tools() == []
+
+
+class TestConvertTools:
+    def test_converts_all_tools(self, toolkit):
+        tools = toolkit._convert_tools(MCP_TOOLS)
+        assert len(tools) == 2
+
+    def test_preserves_name(self, toolkit):
+        tools = toolkit._convert_tools(MCP_TOOLS)
+        assert tools[0].name == "list_charges"
+        assert tools[1].name == "create_refund"
+
+    def test_preserves_description(self, toolkit):
+        tools = toolkit._convert_tools(MCP_TOOLS)
+        assert tools[0].description == "List recent charges"
+
+    def test_missing_description_falls_back_to_name(self, toolkit):
+        tools = toolkit._convert_tools([{"name": "some_tool"}])
+        assert tools[0].description == "some_tool"
+
+    def test_tool_callable(self, toolkit, mock_mcp_client):
+        tools = toolkit._convert_tools(MCP_TOOLS)
+        # Tool function should be callable
+        assert callable(tools[0].func)
+
+
+class TestToolExecution:
+    def test_calls_mcp_run_tool(self, toolkit, mock_mcp_client):
+        tools = toolkit._convert_tools(MCP_TOOLS)
+        result = tools[0].func(limit=10)
+        mock_mcp_client.call_tool.assert_called_once_with(
+            "list_charges", {"limit": 10}, None
+        )
+        assert result == '{"id": "ch_123"}'
+
+
+class TestFactory:
+    @pytest.mark.asyncio
+    async def test_creates_initialized_toolkit(self, mock_mcp_client):
+        with patch(
+            "stripe_agent_toolkit.shared.toolkit_core.StripeMcpClient",
+            return_value=mock_mcp_client,
+        ):
+            mock_mcp_client.get_tools = MagicMock(return_value=MCP_TOOLS)
+            toolkit = await create_stripe_agent_toolkit("rk_test_key")
+            assert toolkit.is_initialized
+            assert len(toolkit.get_tools()) == 2
+            await toolkit.close()


### PR DESCRIPTION
## Why

The toolkit supports OpenAI Agent SDK, LangChain, CrewAI, and Strands but not AG2. AG2 is the community-maintained successor to Microsoft AutoGen and one of the most downloaded multi-agent frameworks on PyPI. This PR adds AG2 as a supported framework, following the same ToolkitCore pattern used by existing adapters.

## What changed

**Toolkit adapter** (`stripe_agent_toolkit/ag2/`)
- `StripeAgentToolkit` subclasses `ToolkitCore` and converts MCP tools to AG2 `Tool` objects with `parameters_json_schema` passthrough. Async-to-sync bridging uses a shared `ThreadPoolExecutor`, consistent with the CrewAI adapter approach.

**Example** (`examples/ag2/`)
- Customer support triage that routes billing queries to an agent with Stripe tools. Demonstrates AG2's handoff system (context-based, tool-based, after-work) in a Stripe context.

**Tests** (`tests/test_ag2_toolkit.py`)
- Unit tests covering tool conversion, name/description preservation, MCP execution delegation, and the async factory function.

**Docs**
- Added `ag2` optional dependency to `pyproject.toml`.
- Updated framework lists in `README.md`, `tools/README.md`, and `tools/python/README.md` with an AG2 usage snippet.

## Testing

- All existing tests pass (`pytest tests/`).
- AG2 adapter tests pass with mocked MCP client.
- Example validated against AG2 0.11+ (imports, agent creation, tool registration, handoff routing, pattern construction).