### PR TITLE
Fix optional parameters to also accept null values

### DIFF
--- a/tools/typescript/src/shared/schema-utils.ts
+++ b/tools/typescript/src/shared/schema-utils.ts
@@ -68,7 +68,7 @@ export function jsonSchemaToZodShape(
     }
 
     if (!required.has(key)) {
-      zodType = zodType.optional();
+      zodType = zodType.optional().nullable();
     }
 
     shape[key] = zodType;

--- a/tools/typescript/src/test/shared/schema-utils.test.ts
+++ b/tools/typescript/src/test/shared/schema-utils.test.ts
@@ -119,6 +119,25 @@ describe('jsonSchemaToZodShape', () => {
     expect(shape.optional_field.isOptional()).toBe(true);
   });
 
+  it('should accept null for optional fields', () => {
+    const shape = jsonSchemaToZodShape({
+      type: 'object',
+      properties: {
+        required_field: {type: 'string'},
+        optional_field: {type: 'string'},
+      },
+      required: ['required_field'],
+    });
+
+    // Optional field should accept null (LLM agents commonly send null)
+    const result = shape.optional_field.safeParse(null);
+    expect(result.success).toBe(true);
+
+    // Required field should not accept null
+    const requiredResult = shape.required_field.safeParse(null);
+    expect(requiredResult.success).toBe(false);
+  });
+
   it('should preserve descriptions', () => {
     const shape = jsonSchemaToZodShape({
       type: 'object',
@@ -208,6 +227,21 @@ describe('jsonSchemaToZod', () => {
     if (result.success) {
       expect(result.data.extra).toBe('field');
     }
+  });
+
+  it('should accept null for optional fields', () => {
+    const schema = jsonSchemaToZod({
+      type: 'object',
+      properties: {
+        email: {type: 'string'},
+        name: {type: 'string'},
+      },
+      required: ['email'],
+    });
+
+    // LLM agents commonly send null for optional parameters
+    const result = schema.safeParse({email: 'john@example.com', name: null});
+    expect(result.success).toBe(true);
   });
 
   it('should work with complex nested schemas', () => {


### PR DESCRIPTION
## Summary
- Add `.nullable()` to optional parameter schemas so agents can pass `null` for unused parameters without Zod validation errors

## Why this matters
[#142](https://github.com/stripe/ai/issues/142) reports that LLM agents (Claude, Cursor, etc.) commonly send `null` for optional parameters. The current schema uses `.optional()` but not `.nullable()`, causing validation failures on valid tool calls.

## Changes
- `tools/typescript/src/shared/schema-utils.ts`: Add `.nullable()` after `.optional()` for non-required parameters
- `tools/typescript/src/test/shared/schema-utils.test.ts`: Add tests confirming optional params accept null values

## Testing
- All 45 existing + new tests pass (`pnpm test`)
- Lint clean (`pnpm lint`)
- New tests verify: optional fields accept `null`, required fields still reject `null`

## Note
The Python SDK (`schema_utils.py`) already handles this correctly via `Optional[type]` with `default=None`, so no changes needed there.

Fixes #142

This contribution was developed with AI assistance (Claude Code).