### PR TITLE
fix(mcp): fail fast when server hangs on unsupported protocol version

### DIFF
--- a/tools/modelcontextprotocol/package-lock.json
+++ b/tools/modelcontextprotocol/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stripe/mcp",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stripe/mcp",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.1",

--- a/tools/modelcontextprotocol/src/index.ts
+++ b/tools/modelcontextprotocol/src/index.ts
@@ -65,6 +65,28 @@ export async function main(): Promise<void> {
   // Wire up message forwarding: stdio -> HTTP
   // The first message is inspected for clientInfo to build the User-Agent.
   let initialized = false;
+  let initializeTimeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+  function clearInitializeTimeout() {
+    if (initializeTimeoutHandle !== null) {
+      clearTimeout(initializeTimeoutHandle);
+      initializeTimeoutHandle = null;
+    }
+  }
+
+  // Wrap the HTTP transport so that any response from the server cancels the
+  // initialize timeout (server is alive and responding normally).
+  function createHttpTransportWithTimeout(
+    userAgent: string
+  ): StreamableHTTPClientTransport {
+    const transport = createHttpTransport(userAgent);
+    const upstream = transport.onmessage;
+    transport.onmessage = async (message) => {
+      clearInitializeTimeout();
+      if (upstream) await upstream(message);
+    };
+    return transport;
+  }
 
   stdioTransport.onmessage = async (message) => {
     try {
@@ -76,11 +98,44 @@ export async function main(): Promise<void> {
         const userAgent = buildUserAgent(clientName);
 
         // Create and start the HTTP transport with the enriched User-Agent
-        httpTransport = createHttpTransport(userAgent);
+        httpTransport = createHttpTransportWithTimeout(userAgent);
         await httpTransport.start();
       }
 
       await httpTransport!.send(message);
+
+      // After forwarding an initialize request, arm a timeout so the client
+      // gets a fast error if the server hangs (e.g. unsupported protocol
+      // version) instead of waiting 60 s for its own timeout to fire.
+      const msg = message as Record<string, unknown>;
+      if (msg.method === 'initialize' && initializeTimeoutHandle === null) {
+        const msgId = msg.id ?? null;
+        initializeTimeoutHandle = setTimeout(() => {
+          initializeTimeoutHandle = null;
+          console.error(
+            red(
+              '\n⏱  Initialize timed out — the remote MCP server did not respond.\n' +
+                '   This often happens when the client sends a protocol version the server\n' +
+                '   does not support (e.g. "2025-11-25"). Try protocol version "2024-11-05".\n'
+            )
+          );
+          // Send a JSON-RPC error back so the client fails fast.
+          stdioTransport
+            .send({
+              jsonrpc: '2.0',
+              id: msgId,
+              error: {
+                code: -32001,
+                message:
+                  'MCP server did not respond to initialize request. ' +
+                  'The server may not support the requested protocol version. ' +
+                  'Try protocol version "2024-11-05".',
+              },
+            } as Parameters<typeof stdioTransport.send>[0])
+            .catch(() => {});
+          httpTransport?.close();
+        }, 10_000);
+      }
     } catch (error) {
       console.error(red('Error forwarding message to server:'), error);
     }
@@ -93,6 +148,7 @@ export async function main(): Promise<void> {
 
   // Handle transport close
   stdioTransport.onclose = () => {
+    clearInitializeTimeout();
     httpTransport?.close();
   };
 


### PR DESCRIPTION
## Problem

Fixes #290

When Claude Desktop (or any MCP client) sends an `initialize` request with `protocolVersion: "2025-11-25"`, the local `@stripe/mcp` proxy forwards the message to `mcp.stripe.com`. The remote server does not support that protocol version and **never responds**, so the client is left hanging for its full 60-second timeout before receiving any error:

```
Message from client: {"method":"initialize","params":{"protocolVersion":"2025-11-25",...},"jsonrpc":"2.0","id":0}

[60 seconds later]

{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":0,"reason":"McpError: MCP error -32001: Request timed out"}}
Server transport closed unexpectedly
```

This violates the MCP spec principle of fail-fast and makes debugging painful.

## Fix

Added a **10-second initialize timeout** in the stdio→HTTP proxy (`src/index.ts`):

- After forwarding the `initialize` message to `mcp.stripe.com`, a 10 s timer is armed.
- If the server responds before the timer fires (the normal case, e.g. with `protocolVersion: "2024-11-05"`), the timer is cleared immediately — **zero impact on the happy path**.
- If the timer fires (server hung), the proxy immediately sends a JSON-RPC `-32001` error back to the client with a clear diagnostic message pointing to `"2024-11-05"` as the supported protocol version, then closes the HTTP transport.

```
⏱  Initialize timed out — the remote MCP server did not respond.
   This often happens when the client sends a protocol version the server
   does not support (e.g. "2025-11-25"). Try protocol version "2024-11-05".
```

The client now fails in ~10 s with an actionable error instead of silently waiting 60 s.

## Testing

- All 17 existing unit tests pass (`npm test`).
- Build compiles cleanly (`npm run build`).
- Manually verified: sending `protocolVersion: "2024-11-05"` still works immediately (timeout is cancelled on first server response).