### PR TITLE
feat(ai-sdk): add AI SDK v6 / @ai-sdk/provider v3 peer dependency support

### DIFF
--- a/llm/ai-sdk/package.json
+++ b/llm/ai-sdk/package.json
@@ -64,10 +64,10 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@ai-sdk/anthropic": "^2.0.41",
-    "@ai-sdk/google": "^2.0.27",
-    "@ai-sdk/openai": "^2.0.59",
-    "ai": "^3.4.7 || ^4.0.0 || ^5.0.0"
+    "@ai-sdk/anthropic": "^2.0.41 || ^3.0.0",
+    "@ai-sdk/google": "^2.0.27 || ^3.0.0",
+    "@ai-sdk/openai": "^2.0.59 || ^3.0.0",
+    "ai": "^3.4.7 || ^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "peerDependenciesMeta": {
     "@ai-sdk/anthropic": {


### PR DESCRIPTION
## Problem

Fixes #296

Users running `ai@6.x` (e.g. `6.0.84`, `6.0.101`) cannot install `@stripe/ai-sdk` cleanly because the package only declares peer dependency compatibility up to `ai@^5.0.0`, and provider packages (`@ai-sdk/anthropic`, `@ai-sdk/google`, `@ai-sdk/openai`) only up to `^2.x`:

```
npm warn peer dep missing: ai@^3.4.7 || ^4.0.0 || ^5.0.0  ← doesn't cover v6
```

This forces users into unsafe casts or manual `--legacy-peer-deps` overrides to adopt the package.

## Root Cause

The `peerDependencies` ranges in `llm/ai-sdk/package.json` were not updated when v6 / provider v3 support was added to the implementation.

## What Was Already Working

The implementation code already fully supports `@ai-sdk/provider@^3`:

- `stripe-language-model-v3.ts` implements `LanguageModelV3`
- `wrapperV3.ts` wraps `LanguageModelV3` models
- `stripe-provider.ts` exports `createStripeV3()` / `stripeV3` using `ProviderV3`
- `package.json` already has `"@ai-sdk/provider": "^3.0.0"` as a **dependency**

The only gap was the **peer dependency metadata** advertised to npm.

## Fix

Updated `peerDependencies` in `llm/ai-sdk/package.json`:

| Package | Before | After |
|---|---|---|
| `ai` | `^3.4.7 \|\| ^4.0.0 \|\| ^5.0.0` | `^3.4.7 \|\| ^4.0.0 \|\| ^5.0.0 \|\| ^6.0.0` |
| `@ai-sdk/anthropic` | `^2.0.41` | `^2.0.41 \|\| ^3.0.0` |
| `@ai-sdk/google` | `^2.0.27` | `^2.0.27 \|\| ^3.0.0` |
| `@ai-sdk/openai` | `^2.0.59` | `^2.0.59 \|\| ^3.0.0` |

No implementation code changes required.

## Testing

- Build and tests pass for all existing configurations.
- Users on `ai@6.x` can now install without peer dependency warnings or `--legacy-peer-deps`.