### PR TITLE
fix(gemini): remove trailing slash from httpUrl to fix OAuth authentication

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "mcpServers": {
     "stripe": {
-      "httpUrl": "https://mcp.stripe.com/",
+      "httpUrl": "https://mcp.stripe.com",
       "oauth": {
         "enabled": true
       }


### PR DESCRIPTION
## Problem

Fixes #221

Gemini CLI users receive the following error when trying to authenticate with the Stripe MCP server:

```
✕ Error during discovery for MCP server 'stripe': Protected resource https://mcp.stripe.com does not match expected https://mcp.stripe.com/
```

This prevents OAuth authentication entirely, making the Gemini CLI extension unusable.

## Root Cause

`gemini-extension.json` declared the MCP server URL **with** a trailing slash:

```json
"httpUrl": "https://mcp.stripe.com/"
```

Every other file in the repo uses the URL **without** a trailing slash:

| File | URL |
|---|---|
| `tools/modelcontextprotocol/server.json` | `https://mcp.stripe.com` |
| `tools/modelcontextprotocol/src/index.ts` | `https://mcp.stripe.com` |
| `providers/claude/plugin/.mcp.json` | `https://mcp.stripe.com` |
| `providers/cursor/plugin/mcp.json` | `https://mcp.stripe.com` |
| `tools/typescript/src/shared/constants.ts` | `https://mcp.stripe.com` |

Per **RFC 9728 (OAuth 2.0 Protected Resource Metadata)**, the `resource` identifier returned in the server's `/.well-known/oauth-protected-resource` document MUST exactly match the URL the client uses. Gemini CLI constructs the expected resource from `httpUrl`, so the trailing slash caused a byte-for-byte mismatch and auth was rejected.

## Fix

Remove the trailing slash from `gemini-extension.json`:

```diff
-"httpUrl": "https://mcp.stripe.com/",
+"httpUrl": "https://mcp.stripe.com",
```

One character change — no logic changes, no other files touched.

## Verification

After this fix, `gemini extensions install` + `gemini` should complete OAuth without the mismatch error.