### PR TITLE
Add recommended security policies for MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,28 @@ Tool permissions are controlled by your Restricted API Key (RAK). Create a RAK w
 
 See [MCP](/tools/modelcontextprotocol) for more details.
 
+### Policy enforcement (optional)
+
+The MCP server exposes tools that can move money (`create_refund`, `finalize_invoice`), create live payment URLs (`create_payment_link`), and cancel subscriptions. Restricted API Keys control which tools are available, but not how often or how aggressively an agent uses them.
+
+You can add rate limits, daily caps, and access control by wrapping the server with [PolicyLayer Intercept](https://github.com/policylayer/intercept), an open-source MCP proxy:
+
+```sh
+npx -y @policylayer/intercept \
+  --policy policies/recommended.yaml \
+  -- npx -y @stripe/mcp --api-key=YOUR_STRIPE_SECRET_KEY
+```
+
+Three policy presets are included in [`/policies`](/policies):
+
+| Policy | Description |
+|--------|-------------|
+| `recommended.yaml` | Rate limits on writes, daily caps on financial tools, reads allowed freely |
+| `strict.yaml` | Default deny — only read tools are allowed unless you explicitly opt in |
+| `permissive.yaml` | Everything allowed, rate limits only on financial and destructive operations |
+
+Policies are YAML files you can edit to match your requirements. See the [Intercept docs](https://github.com/policylayer/intercept) for the full policy reference.
+
 ## Agent toolkit
 
 Stripe's Agent Toolkit enables popular agent frameworks including OpenAI's Agent SDK, LangChain, CrewAI, and Vercel's AI SDK to integrate with Stripe APIs through function calling. The library is not exhaustive of the entire Stripe API. It includes support for Python and TypeScript, and is built directly on top of the Stripe [Python][python-sdk] and [Node][node-sdk] SDKs.

--- a/policies/permissive.yaml
+++ b/policies/permissive.yaml
@@ -1,0 +1,37 @@
+version: "1"
+description: "Stripe MCP — permissive policy. All tools allowed. Rate limits on financial and destructive operations."
+default: allow
+
+tools:
+  # Financial tools — rate limited even in permissive mode
+  create_refund:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "10/hour"
+        on_deny: "Max 10 refunds per hour"
+
+  finalize_invoice:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "20/hour"
+        on_deny: "Max 20 invoice finalisations per hour"
+
+  create_payment_link:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "20/hour"
+        on_deny: "Max 20 payment links per hour"
+
+  # Destructive tools — rate limited
+  cancel_subscription:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "10/hour"
+        on_deny: "Max 10 subscription cancellations per hour"
+
+  # Global safety net
+  "*":
+    rules:
+      - name: "global-rate-limit"
+        rate_limit: "120/minute"
+        on_deny: "Global rate limit — max 120 tool calls per minute"

--- a/policies/recommended.yaml
+++ b/policies/recommended.yaml
@@ -1,0 +1,95 @@
+version: "1"
+description: "Stripe MCP — recommended policy. Rate limits on writes, caps on financial tools, reads allowed freely."
+default: allow
+
+tools:
+  # Financial tools — highest risk, tightest limits
+  create_refund:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "3/minute"
+        on_deny: "Slow down — max 3 refunds per minute"
+      - name: "daily-cap"
+        rate_limit: "10/day"
+        on_deny: "Daily refund limit (10) reached"
+
+  finalize_invoice:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "3/minute"
+        on_deny: "Slow down — max 3 invoice finalisations per minute"
+      - name: "daily-cap"
+        rate_limit: "20/day"
+        on_deny: "Daily invoice finalisation limit (20) reached — finalised invoices trigger payment collection"
+
+  create_payment_link:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "10/hour"
+        on_deny: "Max 10 payment links per hour"
+
+  # Destructive tools — require deliberation
+  cancel_subscription:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "2/minute"
+        on_deny: "Slow down — max 2 cancellations per minute"
+      - name: "daily-cap"
+        rate_limit: "10/day"
+        on_deny: "Daily subscription cancellation limit (10) reached"
+
+  # Write tools — moderate limits
+  create_customer:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "30/hour"
+        on_deny: "Max 30 customer creations per hour"
+
+  create_product:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "30/hour"
+        on_deny: "Max 30 product creations per hour"
+
+  create_price:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "30/hour"
+        on_deny: "Max 30 price creations per hour"
+
+  create_coupon:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "20/hour"
+        on_deny: "Max 20 coupon creations per hour"
+
+  create_invoice:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "20/hour"
+        on_deny: "Max 20 invoice creations per hour"
+
+  create_invoice_item:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "30/hour"
+        on_deny: "Max 30 invoice item creations per hour"
+
+  update_subscription:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "20/hour"
+        on_deny: "Max 20 subscription updates per hour"
+
+  update_dispute:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "10/hour"
+        on_deny: "Max 10 dispute updates per hour"
+
+  # Global safety net
+  "*":
+    rules:
+      - name: "global-rate-limit"
+        rate_limit: "60/minute"
+        on_deny: "Global rate limit — max 60 tool calls per minute across all Stripe tools"

--- a/policies/strict.yaml
+++ b/policies/strict.yaml
@@ -1,0 +1,78 @@
+version: "1"
+description: "Stripe MCP — strict policy. Default deny. Only explicitly allowed tools are accessible."
+default: deny
+
+tools:
+  # Read-only tools — explicitly allowed
+  list_customers:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_products:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_prices:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_invoices:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_subscriptions:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_payment_intents:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_charges:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_disputes:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_coupons:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  retrieve_balance:
+    rules:
+      - action: allow
+        rate_limit: "10/minute"
+
+  get_stripe_account_info:
+    rules:
+      - action: allow
+        rate_limit: "10/minute"
+
+  search_stripe_resources:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  fetch_stripe_resources:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  search_stripe_documentation:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  # Everything else blocked by default: deny
+  # To allow writes, copy rules from recommended.yaml


### PR DESCRIPTION

## Summary

Adds three YAML policy files for use with [PolicyLayer Intercept](https://github.com/policylayer/intercept), an open-source MCP proxy that enforces rate limits, spend caps, and access control on tool calls.

The Stripe MCP server exposes 27 tools — including `create_refund`, `finalize_invoice`, `cancel_subscription`, and `create_payment_link` — which can move money or destroy data. Restricted API Keys control *which* tools appear, but there's no rate limiting, spend capping, or audit logging on *how* those tools are used once available.

These policies add that layer without any changes to the server itself.

## What's included

```
policies/
├── recommended.yaml   # Sensible defaults for most teams
├── strict.yaml        # Read-only. Default deny, explicit allowlist
└── permissive.yaml    # Everything allowed, rate limits on financial ops
```

**recommended.yaml** — good starting point:
- Financial tools (`create_refund`, `finalize_invoice`): 3/minute burst + daily caps
- Destructive tools (`cancel_subscription`): 2/minute burst + 10/day cap
- Write tools (`create_customer`, `create_product`, etc.): 30/hour
- Read tools: allowed, 60/minute global limit

**strict.yaml** — for production/compliance:
- Default deny — only read tools are allowed
- All writes, financial ops, and destructive ops blocked unless you explicitly opt in

**permissive.yaml** — for development:
- Everything allowed, rate limits only on financial and destructive operations

## Usage

Wrap the MCP server with Intercept (one line):

```bash
npx -y @policylayer/intercept \
  --policy policies/recommended.yaml \
  -- npx -y @stripe/mcp --api-key=$STRIPE_SECRET_KEY
```

Or in Claude Desktop config:

```json
{
  "mcpServers": {
    "stripe": {
      "command": "npx",
      "args": [
        "-y", "@policylayer/intercept",
        "--policy", "policies/recommended.yaml",
        "--", "npx", "-y", "@stripe/mcp",
        "--api-key", "sk_..."
      ]
    }
  }
}
```

## Why this matters

RAKs control access but not behaviour. An agent with `create_refund` permission can issue unlimited refunds with no rate limit, no daily cap, and no audit trail. These policies add deterministic, transport-layer enforcement that complements RAK permissions.

## About PolicyLayer Intercept

- Open source (MIT): [github.com/policylayer/intercept](https://github.com/policylayer/intercept)
- npm: `@policylayer/intercept`
- Sub-millisecond evaluation, fail-closed, deterministic (not prompt-based)
- Supports all MCP clients: Claude Desktop, Claude Code, Cursor, VS Code, Windsurf, etc.
- Zero changes to the MCP server — wraps the command transparently