### PR TITLE
Docs: Outdated terminology in token meter docs comments

### DIFF
--- a/llm/token-meter/types.ts
+++ b/llm/token-meter/types.ts
@@ -1,5 +1,5 @@
 /**
- * Type definitions for token-billing
+ * Type definitions for token-meter
  * Re-exports shared types for backward compatibility
  */
 


### PR DESCRIPTION
## Problem

The file-level comments refer to "token-billing" even though the package/module is now named `token-meter`. This creates confusion for contributors searching for the current module name and can propagate stale terminology into external docs.

**Severity**: `low`
**File**: `llm/token-meter/types.ts`

## Solution

Update the header comment to use consistent naming, e.g. "Type definitions for token-meter".

## Changes

- `llm/token-meter/types.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
