### PR TITLE
fix(ai-sdk): prevent stack overflow in file-part base64 conversion

### DIFF
--- a/llm/ai-sdk/provider/base64.ts
+++ b/llm/ai-sdk/provider/base64.ts
@@ -1,0 +1,18 @@
+const BINARY_STRING_CHUNK_SIZE = 0x8000;
+
+export function uint8ArrayToBase64(data: Uint8Array): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString(
+      'base64'
+    );
+  }
+
+  const binaryChunks: string[] = [];
+
+  for (let index = 0; index < data.length; index += BINARY_STRING_CHUNK_SIZE) {
+    const chunk = data.subarray(index, index + BINARY_STRING_CHUNK_SIZE);
+    binaryChunks.push(String.fromCharCode(...chunk));
+  }
+
+  return btoa(binaryChunks.join(''));
+}

--- a/llm/ai-sdk/provider/tests/utils-v3.test.ts
+++ b/llm/ai-sdk/provider/tests/utils-v3.test.ts
@@ -85,6 +85,33 @@ describe('Stripe Provider V3 Utils', () => {
       ]);
     });
 
+    it('should convert large file Uint8Array without overflowing the stack', () => {
+      const data = Uint8Array.from({length: 200_000}, (_, index) => index % 256);
+      const prompt: LanguageModelV3Prompt = [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data,
+              mediaType: 'image/png',
+            },
+          ],
+        },
+      ];
+
+      const result = convertToOpenAIMessagesV3(prompt);
+
+      expect(result[0].content).toEqual([
+        {
+          type: 'image_url',
+          image_url: {
+            url: `data:image/png;base64,${Buffer.from(data).toString('base64')}`,
+          },
+        },
+      ]);
+    });
+
     it('should convert assistant message with text', () => {
       const prompt: LanguageModelV3Prompt = [
         {

--- a/llm/ai-sdk/provider/tests/utils.test.ts
+++ b/llm/ai-sdk/provider/tests/utils.test.ts
@@ -88,6 +88,28 @@ describe('Stripe Provider Utils', () => {
       expect(content[0].image_url.url).toMatch(/^data:image\/png;base64,/);
     });
 
+    it('should convert large file Uint8Array without overflowing the stack', () => {
+      const fileData = Uint8Array.from({length: 200_000}, (_, index) => index % 256);
+
+      const result = convertToOpenAIMessages([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data: fileData,
+              mediaType: 'image/png',
+            },
+          ],
+        },
+      ]);
+
+      const content = result[0].content as any[];
+      expect(content[0].image_url.url).toBe(
+        `data:image/png;base64,${Buffer.from(fileData).toString('base64')}`
+      );
+    });
+
     it('should convert assistant message with text', () => {
       const result = convertToOpenAIMessages([
         {
@@ -459,4 +481,3 @@ describe('Stripe Provider Utils', () => {
     });
   });
 });
-

--- a/llm/ai-sdk/provider/utils-v3.ts
+++ b/llm/ai-sdk/provider/utils-v3.ts
@@ -6,6 +6,7 @@ import type {
   LanguageModelV3Prompt,
   LanguageModelV3FinishReason,
 } from '@ai-sdk/provider';
+import {uint8ArrayToBase64} from './base64';
 
 type AssistantMessage = Extract<
   LanguageModelV3Prompt[number],
@@ -96,9 +97,7 @@ export function convertToOpenAIMessagesV3(
               } else if (part.data instanceof URL) {
                 fileUrl = part.data.toString();
               } else {
-                const base64 = btoa(
-                  String.fromCharCode(...Array.from(part.data))
-                );
+                const base64 = uint8ArrayToBase64(part.data);
                 fileUrl = `data:${part.mediaType};base64,${base64}`;
               }
 

--- a/llm/ai-sdk/provider/utils.ts
+++ b/llm/ai-sdk/provider/utils.ts
@@ -6,6 +6,7 @@ import {
   LanguageModelV2Prompt,
   LanguageModelV2FinishReason,
 } from '@ai-sdk/provider';
+import {uint8ArrayToBase64} from './base64';
 
 type AssistantMessage = Extract<
   LanguageModelV2Prompt[number],
@@ -95,9 +96,7 @@ export function convertToOpenAIMessages(
               fileUrl = part.data.toString();
             } else {
               // Convert Uint8Array to base64 data URL
-              const base64 = btoa(
-                String.fromCharCode(...Array.from(part.data))
-              );
+              const base64 = uint8ArrayToBase64(part.data);
               fileUrl = `data:${part.mediaType};base64,${base64}`;
             }
             


### PR DESCRIPTION
## Summary

Large file message parts were being converted to Base64 with String.fromCharCode(...Array.from(part.data)), which can exceed Node's argument limit and throw a RangeError. That made it possible for a moderately large uploaded file to crash the process.

This change replaces that conversion with a safe helper that:

  - uses Buffer when available
  - falls back to chunked conversion when needed
  - applies the fix to both the V2 and V3 provider message converters

  ## Testing

  - npm test -- --runInBand --watchman=false provider/tests
  - npm run build

  ## Notes

  Added regression coverage for large Uint8Array file payloads so this stack overflow path is caught in both converter variants.